### PR TITLE
fix(Icon): fix proptypes warning when 3rd party icon is used

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,6 +8,7 @@ import { SpacingSizeValuePropType } from '../../types/spacing.types';
 import { pxToRem } from '../../utils/helpers';
 import { Spinner } from '../Spinner';
 import { IconTypes, SSCIconNames } from '../Icon/Icon.enums';
+import { SSCIcons, Types } from '../Icon/Icon.types';
 import StyledButton from './StyledButton';
 import StyledIcon from './StyledIcon';
 import { ButtonColors, ButtonSizes, ButtonVariants } from './Button.enums';
@@ -111,8 +112,14 @@ Button.propTypes = {
     }),
   ]),
   className: PropTypes.string,
-  iconName: PropTypes.oneOf(Object.values(SSCIconNames)),
-  iconType: PropTypes.oneOf(Object.values(IconTypes)),
+  iconName: PropTypes.oneOfType([
+    PropTypes.oneOf<SSCIcons>(Object.values(SSCIconNames)),
+    PropTypes.string,
+  ]),
+  iconType: PropTypes.oneOfType([
+    PropTypes.oneOf<Types>(Object.values(IconTypes)),
+    PropTypes.string,
+  ]),
   onClick: PropTypes.func,
 };
 

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -21,6 +21,6 @@ export interface ButtonProps {
   href?: string;
   to?: To;
   className?: string;
-  iconName?: SSCIcons;
-  iconType?: IconTypes;
+  iconName?: SSCIcons | string;
+  iconType?: IconTypes | string;
 }

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
+  IconName,
   IconPrefix,
   findIconDefinition,
 } from '@fortawesome/fontawesome-svg-core';
@@ -11,7 +12,7 @@ import { isNotUndefined } from 'ramda-adjunct';
 import { getColor } from '../../utils/helpers';
 import { ColorTypes } from '../../theme/colors.enums';
 import { Colors } from '../../theme/colors.types';
-import { IconProps } from './Icon.types';
+import { IconProps, SSCIcons, Types } from './Icon.types';
 import { IconTypes, SSCIconNames } from './Icon.enums';
 
 const StyledIcon = styled(FontAwesomeIcon)<{ color: keyof Colors }>`
@@ -31,14 +32,23 @@ const Icon: React.FC<IconProps> = ({
     className={className}
     color={color}
     fixedWidth={hasFixedWidth}
-    icon={findIconDefinition({ iconName: name, prefix: type as IconPrefix })}
+    icon={findIconDefinition({
+      iconName: name as IconName,
+      prefix: type as IconPrefix,
+    })}
     {...props}
   />
 );
 
 Icon.propTypes = {
-  name: PropTypes.oneOf(Object.values(SSCIconNames)).isRequired,
-  type: PropTypes.oneOf(Object.values(IconTypes)),
+  name: PropTypes.oneOfType([
+    PropTypes.oneOf<SSCIcons>(Object.values(SSCIconNames)),
+    PropTypes.string,
+  ]).isRequired,
+  type: PropTypes.oneOfType([
+    PropTypes.oneOf<Types>(Object.values(IconTypes)),
+    PropTypes.string,
+  ]),
   color: PropTypes.oneOf(Object.values(ColorTypes)),
   className: PropTypes.string,
   hasFixedWidth: PropTypes.bool,

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -5,8 +5,8 @@ export type SSCIcons = typeof SSCIconNames[keyof typeof SSCIconNames];
 export type Types = typeof IconTypes[keyof typeof IconTypes];
 
 export interface BaseIconProps {
-  name: SSCIcons;
-  type?: Types;
+  name: SSCIcons | string;
+  type?: Types | string;
 }
 
 export interface IconProps extends BaseIconProps {

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -7,6 +7,7 @@ import { pxToRem } from '../../utils/helpers';
 import { Button } from '../Button';
 import { ButtonVariants } from '../Button/Button.enums';
 import { Icon } from '../Icon';
+import { SSCIcons, Types } from '../Icon/Icon.types';
 import { IconTypes, SSCIconNames } from '../Icon/Icon.enums';
 import { IconButtonProps } from './IconButton.types';
 
@@ -51,8 +52,14 @@ IconButton.propTypes = {
       hash: PropTypes.string,
     }).isRequired,
   ]),
-  iconName: PropTypes.oneOf(Object.values(SSCIconNames)),
-  iconType: PropTypes.oneOf(Object.values(IconTypes)),
+  iconName: PropTypes.oneOfType([
+    PropTypes.oneOf<SSCIcons>(Object.values(SSCIconNames)),
+    PropTypes.string,
+  ]),
+  iconType: PropTypes.oneOfType([
+    PropTypes.oneOf<Types>(Object.values(IconTypes)),
+    PropTypes.string,
+  ]),
   onClick: PropTypes.func,
 };
 


### PR DESCRIPTION
When `Icon` based components are used in 3rd-party integration with an extended icon library proptypes are throwing warnings about invalid values.
<img width="434" alt="Screenshot 2020-12-03 at 16 21 23" src="https://user-images.githubusercontent.com/18654425/101049505-e130ed00-3583-11eb-97dc-334ac9c73072.png">

This PR adding generic `string` type for icon type and icon name props to prevent these warnings. 