### PR TITLE
fix(router): make react-router-dom optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,8 @@
     "chromatic": "npx chromatic storybook:build"
   },
   "peerDependencies": {
-    "prop-types": "^15.7.2",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0",
     "react-router-dom": "^5.2.0",
     "styled-components": "^5.1.0"
   },
@@ -44,6 +43,7 @@
     "@types/styled-components": "^5.1.0",
     "csstype": "^3.0.0-beta.4",
     "polished": "^3.6.5",
+    "prop-types": "^15.7.2",
     "ramda": "^0.27.0",
     "ramda-adjunct": "^2.16.1",
     "react-select": "^3.1.0",
@@ -72,6 +72,7 @@
     "@testing-library/react": "^10.3.0",
     "@types/history": "^4.7.7",
     "@types/jest": "^26.0.0",
+    "@types/node": "^14.14.11",
     "@types/react-select": "^3.0.16",
     "@typescript-eslint/eslint-plugin": "^4.0.0",
     "@typescript-eslint/parser": "^4.0.0",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { isNotNull, isNotUndefined, noop } from 'ramda-adjunct';
-import { Link } from 'react-router-dom';
+import { isNotNull, isNotUndefined, isNull, noop } from 'ramda-adjunct';
 import styled from 'styled-components';
 
 import { SpacingSizeValuePropType } from '../../types/spacing.types';
@@ -13,6 +12,7 @@ import StyledButton from './StyledButton';
 import StyledIcon from './StyledIcon';
 import { ButtonColors, ButtonSizes, ButtonVariants } from './Button.enums';
 import { ButtonProps } from './Button.types';
+import { requireRouterLink } from '../../utils/require-router-link';
 
 const LoadingText = styled.span<Pick<ButtonProps, 'size' | 'variant'>>`
   padding-right: ${({ variant, size }) =>
@@ -30,7 +30,7 @@ const spinnerSizes = {
 };
 
 const Button: React.FC<
-  Omit<React.HTMLProps<HTMLButtonElement>, 'size'> & ButtonProps
+  ButtonProps & React.ComponentProps<typeof StyledButton>
 > = ({
   children,
   variant = ButtonVariants.solid,
@@ -38,6 +38,7 @@ const Button: React.FC<
   size = ButtonSizes.md,
   iconName,
   iconType = IconTypes.ssc,
+  as = null,
   href = null,
   to = null,
   margin = 'none',
@@ -47,11 +48,20 @@ const Button: React.FC<
   isExpanded = false,
   ...props
 }) => {
+  let RouterLink = null;
+  if (isNull(as) && isNotNull(to)) {
+    RouterLink = requireRouterLink();
+  }
+
   const domTag = isNotNull(href)
     ? 'a' // render 'a' tag if 'href' is present
     : isNotNull(to)
-    ? Link // render 'Link' if 'to' is present
+    ? RouterLink // render 'Link' if 'to' is present
     : undefined; // use default
+
+  if (isNull(RouterLink) && isNull(domTag)) {
+    return null;
+  }
 
   const content = isLoading ? (
     <>

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -9,7 +9,8 @@ export type Variants = typeof ButtonVariants[keyof typeof ButtonVariants];
 export type Sizes = typeof ButtonSizes[keyof typeof ButtonSizes];
 export type Colors = typeof ButtonColors[keyof typeof ButtonColors];
 
-export interface ButtonProps {
+export interface ButtonProps
+  extends Omit<React.HTMLProps<HTMLButtonElement>, 'size' | 'as'> {
   variant?: Variants;
   size?: Sizes;
   color?: Colors;

--- a/src/components/Nav/Nav.stories.tsx
+++ b/src/components/Nav/Nav.stories.tsx
@@ -27,30 +27,22 @@ export const NavigationWithRelativeLinksDefault: Story = () => (
 
 export const NavigationWithAbsoluteLinks: Story = () => (
   <Nav>
-    <NavItem as="a" href="#" isActive>
+    <NavItem href="#" isActive>
       Open
     </NavItem>
-    <NavItem as="a" href="#">
-      Under Review
-    </NavItem>
-    <NavItem as="a" href="#">
-      Resolved
-    </NavItem>
-    <NavItem as="a" href="#">
-      Declined
-    </NavItem>
-    <NavItem as="a" href="#">
-      Decayed
-    </NavItem>
+    <NavItem href="#">Under Review</NavItem>
+    <NavItem href="#">Resolved</NavItem>
+    <NavItem href="#">Declined</NavItem>
+    <NavItem href="#">Decayed</NavItem>
   </Nav>
 );
 
 export const NavigationWithOnClickHandlers: Story = () => (
   <Nav>
-    <NavItem as="a" tabIndex={0} isActive onClick={action('NavItem-click')}>
+    <NavItem tabIndex={0} isActive onClick={action('NavItem-click')}>
       Overview
     </NavItem>
-    <NavItem as="a" tabIndex={-1} onClick={action('NavItem-click')}>
+    <NavItem tabIndex={-1} onClick={action('NavItem-click')}>
       Activity
     </NavItem>
   </Nav>

--- a/src/components/Nav/NavItem.tsx
+++ b/src/components/Nav/NavItem.tsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 
 import {
   getColor,
@@ -9,18 +8,28 @@ import {
   getLineHeight,
   pxToRem,
 } from '../../utils/helpers';
+import { Button } from '../Button';
+import { ButtonVariants } from '../Button/Button.enums';
 import { NavItemProps } from './NavItem.types';
 
-const NavItem = styled(Link).withConfig<NavItemProps>({
-  shouldForwardProp: (prop) => prop !== 'isActive',
-})`
+const NavItem = styled(Button)
+  .attrs(() => ({
+    variant: ButtonVariants.text,
+  }))
+  .withConfig<NavItemProps>({
+    shouldForwardProp: (prop) => prop !== 'isActive',
+  })`
   display: block;
   font-size: ${getFontSize('lg')};
-  font-weight: ${({ isActive }) => isActive && getFontWeight('bold')};
+  font-weight: ${({ isActive }) =>
+    isActive ? getFontWeight('bold') : getFontWeight('regular')};
   line-height: ${getLineHeight('lg')};
   cursor: pointer;
   color: ${({ isActive }) =>
     getColor(isActive ? 'graphite4B' : 'blueberryClassic')};
+  padding: 0;
+  height: auto;
+
   &:not(:first-of-type) {
     padding-left: ${pxToRem(8)};
   }

--- a/src/components/Nav/NavItem.types.ts
+++ b/src/components/Nav/NavItem.types.ts
@@ -1,3 +1,6 @@
-export interface NavItemProps {
+import { ButtonProps } from '../Button/Button.types';
+
+export interface NavItemProps extends ButtonProps {
   isActive?: boolean;
+  variant: 'text';
 }

--- a/src/components/typography/Link/Link.tsx
+++ b/src/components/typography/Link/Link.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { isNotNull, isNull } from 'ramda-adjunct';
-import { Link as RouterLink } from 'react-router-dom';
 
 import { getButtonColor } from '../../../utils/helpers';
+import { requireRouterLink } from '../../../utils/require-router-link';
 import { LinkProps } from './Link.types';
 import { LinkColors } from './Link.enums';
 
@@ -51,6 +51,11 @@ const Link: React.FC<LinkProps & React.ComponentProps<typeof StyledLink>> = ({
   onClick,
   ...props
 }) => {
+  let RouterLink = null;
+  if (isNull(as) && isNotNull(to)) {
+    RouterLink = requireRouterLink();
+  }
+
   const domTag =
     as ||
     (isNotNull(to)
@@ -58,6 +63,10 @@ const Link: React.FC<LinkProps & React.ComponentProps<typeof StyledLink>> = ({
       : isNull(to) && isNull(href)
       ? 'button' // render 'button' if 'to' and 'href' is not present
       : undefined); // use default
+
+  if (isNull(RouterLink) && isNull(domTag)) {
+    return null;
+  }
 
   return (
     <StyledLink

--- a/src/utils/require-router-link.ts
+++ b/src/utils/require-router-link.ts
@@ -1,0 +1,17 @@
+export const requireRouterLink = (): React.ReactNode | null => {
+  try {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    return require('react-router-dom').Link;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `You're trying to use Link component without 'react-router-dom' installed as dependency
+of your project. To resolve this issue you can:
+- install 'react-router-dom' as project dependency
+- replace 'to' property with 'href'
+- pass your custom Link component in 'as' property
+`,
+    );
+    return null;
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["jest"]
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*", "jest.setup.ts"],
   "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3002,6 +3002,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.7.tgz#cf8b6ac088dd9182ac9a1d765f787a8d12490c04"
   integrity sha512-zvjOU1g4CpPilbTDUATnZCUb/6lARMRAqzT7ILwl1P3YvU2leEcZ2+fw9+Jrw/paXB1CgQyXTrN4hWDtqT9O2A==
 
+"@types/node@^14.14.11":
+  version "14.14.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.11.tgz#fc25a4248a5e8d0837019b1d170146d07334abe0"
+  integrity sha512-BJ97wAUuU3NUiUCp44xzUFquQEvnk1wu7q4CMEUYKJWjdkr0YWYDsm4RFtAvxYsNjLsKcrFt6RvK8r+mnzMbEQ==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
This PR is making `react-router-dom` optional and dynamic dependency, that means you don't have to have router included in your project e.g. Next is using its own router and make `react-router-dom` unnecessary.
When `react-router-dom` is not installed and you try to use either Button or Link component with `to` property and without specified component or tag in `as` property library will throw an error in the console with possible solutions and will not render anything in DOM.

There is one caveat with this solution if you're using this library without `react-router-dom` it will show a warning about missing module in the console. I haven't found a solution to this but a user can disable the warning in Webpack in his application.