### PR TITLE
fix(ToolTabItem): require conflict for tool actions

### DIFF
--- a/src/components/Datatable/ToolsTabItem/ToolsTabItem.tsx
+++ b/src/components/Datatable/ToolsTabItem/ToolsTabItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { isNotUndefined, noop } from 'ramda-adjunct';
+import { isNotUndefined } from 'ramda-adjunct';
 import styled from 'styled-components';
 
 import {
@@ -85,8 +85,8 @@ const AppliedToolsTabItem = styled(DefaultToolsTabItem)`
 const ToolsTabItem: React.FC<ToolsTabItemProps> = ({
   label,
   toolState = ToolsTabItemStates.default,
-  onToolActivate = noop,
-  onToolDeactivate = noop,
+  onToolActivate,
+  onToolDeactivate,
   iconName,
   iconType = IconTypes.ssc,
   margin,
@@ -96,12 +96,16 @@ const ToolsTabItem: React.FC<ToolsTabItemProps> = ({
   const [currentToolState, setCurrentToolState] = useState(toolState);
 
   const onClickNotActive = (event) => {
-    onToolActivate(event);
+    if (isNotUndefined(onToolActivate)) {
+      onToolActivate(event);
+    }
     setCurrentToolState(ToolsTabItemStates.active);
   };
 
   const onClickActive = (event) => {
-    onToolDeactivate(event);
+    if (isNotUndefined(onToolDeactivate)) {
+      onToolDeactivate(event);
+    }
     setCurrentToolState(ToolsTabItemStates.applied);
   };
 

--- a/src/components/Datatable/ToolsTabItem/ToolsTabItem.types.ts
+++ b/src/components/Datatable/ToolsTabItem/ToolsTabItem.types.ts
@@ -16,8 +16,8 @@ type ToolStates = typeof ToolsTabItemStates[keyof typeof ToolsTabItemStates];
 export type ToolsTabItem = {
   label: string;
   toolState?: ToolStates;
-  onToolActivate: React.MouseEventHandler;
-  onToolDeactivate: React.MouseEventHandler;
+  onToolActivate?: React.MouseEventHandler;
+  onToolDeactivate?: React.MouseEventHandler;
   iconName?: SSCIcons | string;
   iconType?: IconTypes | string;
   isDisabled?: boolean;
@@ -47,6 +47,6 @@ export const ToolsTabItemPropType = {
   ]),
   margin: SpacingSizeValuePropType,
   className: PropTypes.string,
-  onToolActivate: PropTypes.func.isRequired,
-  onToolDeactivate: PropTypes.func.isRequired,
+  onToolActivate: PropTypes.func,
+  onToolDeactivate: PropTypes.func,
 };


### PR DESCRIPTION
onToolActivate and onToolDeactivate are not required in `ControlsConfig` but required in `ToolsTabItem` 

When missing, we get this error in ui-core

```Uncaught TypeError: Cannot read property 'onToolActivate' of undefined```