### PR TITLE
feat(DsProvider): allow DS context configuration

### DIFF
--- a/src/components/Datatable/Table/Body/renderers/CellRenderer.test.tsx
+++ b/src/components/Datatable/Table/Body/renderers/CellRenderer.test.tsx
@@ -7,6 +7,7 @@ import { renderWithProviders } from '../../../../../utils/tests/renderWithProvid
 import CellRenderer from './CellRenderer';
 import { CellTypes } from './renderers.enums';
 import { abbreviateNumber } from '../../../../../utils/helpers';
+import { defaultDSContext } from '../../../../../theme/DSProvider/DSProvider';
 
 const row = ({ original: { col: 'val' } } as unknown) as Row<
   Record<string, unknown>
@@ -265,9 +266,9 @@ describe('Datatable/CellRenderer', () => {
       const value = screen.getByText(singleValue);
       fireEvent.mouseEnter(value);
 
-      expect(document.getElementById('react-cool-portal')).toHaveTextContent(
-        singleValue,
-      );
+      expect(
+        document.getElementById(defaultDSContext.portalsContainerId),
+      ).toHaveTextContent(singleValue);
     });
     it('should call "tooltipComposer" with correct arguments for each visible value', () => {
       const tooltipComposerMock = jest.fn();

--- a/src/components/Datatable/Table/Body/renderers/MultiValueRenderer.test.tsx
+++ b/src/components/Datatable/Table/Body/renderers/MultiValueRenderer.test.tsx
@@ -5,6 +5,7 @@ import { join, pipe, slice } from 'ramda';
 import { renderWithProviders } from '../../../../../utils/tests/renderWithProviders';
 import MultiValueRenderer from './MultiValueRenderer';
 import { abbreviateNumber } from '../../../../../utils/helpers';
+import { defaultDSContext } from '../../../../../theme/DSProvider/DSProvider';
 
 const values = ['a', 'b', 'c', 'd', 'e'];
 const numberOfVisibleItems = 2;
@@ -30,9 +31,9 @@ describe('Datatable/MultiValueRenderer', () => {
 
     fireEvent.mouseEnter(screen.getByText(`+ ${restValuesCount}`));
 
-    expect(document.getElementById('react-cool-portal')).toHaveTextContent(
-      restValuesText,
-    );
+    expect(
+      document.getElementById(defaultDSContext.portalsContainerId),
+    ).toHaveTextContent(restValuesText);
   });
   it('should open tooltip when hover on value pill', () => {
     renderWithProviders(
@@ -46,9 +47,9 @@ describe('Datatable/MultiValueRenderer', () => {
 
     fireEvent.mouseEnter(screen.getByText(values[0]));
 
-    expect(document.getElementById('react-cool-portal')).toHaveTextContent(
-      values[0],
-    );
+    expect(
+      document.getElementById(defaultDSContext.portalsContainerId),
+    ).toHaveTextContent(values[0]);
   });
   it('should call "tooltipComposer" with correct arguments for each visible value', () => {
     const tooltipComposerMock = jest.fn();
@@ -147,8 +148,8 @@ describe('Datatable/MultiValueRenderer', () => {
       document.getElementsByClassName('ds-table-cell-multivalue')[0],
     ).toHaveTextContent('1K2K+ 1');
     fireEvent.mouseEnter(screen.getByText('+ 1'));
-    expect(document.getElementById('react-cool-portal')).toHaveTextContent(
-      '3K',
-    );
+    expect(
+      document.getElementById(defaultDSContext.portalsContainerId),
+    ).toHaveTextContent('3K');
   });
 });

--- a/src/components/Tooltip/hooks/useTooltip.tsx
+++ b/src/components/Tooltip/hooks/useTooltip.tsx
@@ -1,9 +1,10 @@
 import { isNotNull } from 'ramda-adjunct';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import usePortal from 'react-cool-portal';
 
 import { useCalculatePortaPlacement } from '../../../hooks/useCalculatePortalPlacement';
 import { StyleProps } from '../../../hooks/useCalculatePortalPlacement.types';
+import { DSContext } from '../../../theme/DSProvider/DSProvider';
 import TooltipPopup from '../TooltipPopup';
 import { UseTooltipOptions, UseTooltipReturnType } from './useTooltip.types';
 
@@ -13,8 +14,11 @@ export const useTooltip = (
   parentRef: React.MutableRefObject<HTMLSpanElement>,
   { defaultIsPopupDisplayed = false, placement }: UseTooltipOptions,
 ): UseTooltipReturnType => {
+  const { portalsContainerId } = useContext(DSContext);
   const { Portal, isShow, show, hide } = usePortal({
     defaultShow: defaultIsPopupDisplayed,
+    containerId: portalsContainerId,
+    autoRemoveContainer: false,
   });
   const [style, setStyle] = useState<StyleProps>(defaultTooltipPopupDimensions);
   const getPlacementStyles = useCalculatePortaPlacement(parentRef, {

--- a/src/hooks/useDropdown.tsx
+++ b/src/hooks/useDropdown.tsx
@@ -1,5 +1,11 @@
 import { isNotNull, isNotUndefined } from 'ramda-adjunct';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import usePortal from 'react-cool-portal';
 
 import { useCalculatePortaPlacement } from './useCalculatePortalPlacement';
@@ -7,6 +13,7 @@ import { StyleProps } from './useCalculatePortalPlacement.types';
 import { PortalPlacements } from './useCalculatePortalPlacements.enums';
 import DropdownPane from './components/DropdownPane';
 import { UseDropdownOptions, UseDropdownReturnType } from './useDropdown.types';
+import { DSContext } from '../theme/DSProvider/DSProvider';
 
 const defaultTooltipPopupDimensions = { space: 8 };
 
@@ -20,8 +27,11 @@ export const useDropdown = (
     isElevated = false,
   }: UseDropdownOptions,
 ): UseDropdownReturnType => {
+  const { portalsContainerId } = useContext(DSContext);
   const { Portal, isShow, show, hide, toggle } = usePortal({
     defaultShow: defaultIsPaneDisplayed,
+    containerId: portalsContainerId,
+    autoRemoveContainer: false,
   });
   const [style, setStyle] = useState<StyleProps>({
     width: paneWidth,

--- a/src/theme/DSProvider/DSProvider.stories.mdx
+++ b/src/theme/DSProvider/DSProvider.stories.mdx
@@ -8,7 +8,7 @@ import DSProvider from './DSProvider';
 In order to use Design System components you need to add `styled-components` theme provider.
 You can extend [default Design System theme](/?path=/docs/theme-theme-object--page) with you own
 values when `theme` prop is passed into the component. This component also includes reset CSS rules
-(this is opt-out feature via `includeGlobalStyles` property).
+(this is opt-out feature via `config.hasIncludedGlobalStyles` property).
 
 
 <ArgsTable of={DSProvider} />

--- a/src/theme/DSProvider/DSProvider.tsx
+++ b/src/theme/DSProvider/DSProvider.tsx
@@ -5,26 +5,39 @@ import { mergeDeepRight } from 'ramda';
 
 import { theme as defaultTheme } from '../theme';
 import { GlobalStyles } from '../GlobalStyles';
-import { DSProviderProps } from './DSProvider.types';
+import { DSContextValue, DSProviderProps } from './DSProvider.types';
+
+export const defaultDSContext = {
+  portalsContainerId: 'portals',
+  hasIncludedGlobalStyles: true,
+};
+export const DSContext = React.createContext<DSContextValue>(defaultDSContext);
 
 const DSProvider: React.FC<DSProviderProps> = ({
   children,
   theme = {},
-  hasIncludedGlobalStyles = true,
+  config = {},
 }) => {
   const dsTheme = mergeDeepRight(defaultTheme, theme);
+  const { hasIncludedGlobalStyles, ...dsConfig } = mergeDeepRight(
+    defaultDSContext,
+    config,
+  );
 
   return (
     <ThemeProvider theme={dsTheme}>
       {hasIncludedGlobalStyles && <GlobalStyles />}
-      {children}
+      <DSContext.Provider value={dsConfig}>{children}</DSContext.Provider>
     </ThemeProvider>
   );
 };
 
 DSProvider.propTypes = {
   theme: PropTypes.shape({}),
-  hasIncludedGlobalStyles: PropTypes.bool,
+  config: PropTypes.shape({
+    portalsContainer: PropTypes.string,
+    hasIncludedGlobalStyles: PropTypes.bool,
+  }),
 };
 
 export default DSProvider;

--- a/src/theme/DSProvider/DSProvider.types.ts
+++ b/src/theme/DSProvider/DSProvider.types.ts
@@ -1,6 +1,18 @@
+import { DefaultTheme } from 'styled-components';
+
+export interface DSContextValue {
+  portalsContainerId: string;
+  hasIncludedGlobalStyles: boolean;
+}
 export interface DSProviderProps {
-  theme?: {
-    [key: string]: unknown;
-  };
-  hasIncludedGlobalStyles?: boolean;
+  /**
+   * Override and extends default theme.
+   *
+   * See: [Default theme](/?path=/docs/theme-theme-object--page)
+   */
+  theme?: Partial<DefaultTheme> & Record<string, unknown>;
+  /**
+   * Design system config object
+   */
+  config?: Partial<DSContextValue>;
 }


### PR DESCRIPTION
We hit issue with passing custom styled-components into the Tooltip component. Since in platform we are namespacing component to avoid conflicts with legacy SCSS files and portals container is created outside of `#root` element styles (there is no matching selector) are not applied to custom styled-components inside Tooltip and Dropdown components.