### PR TITLE
fix(Button): stop forwarding margin prop to DOM

### DIFF
--- a/src/components/Button/StyledButton.tsx
+++ b/src/components/Button/StyledButton.tsx
@@ -220,6 +220,7 @@ const StyledButton = styled.button.withConfig<BaseStyledButtonProps>({
       'variant',
       'color',
       'icon',
+      'margin',
       'isLoading',
       'isDisabled',
       'isExpanded',


### PR DESCRIPTION
Stops forwarding the ```margin``` React property to the DOM as an HTML attribute.

<img width="1240" alt="Screen Shot 2021-05-24 at 2 05 46 PM" src="https://user-images.githubusercontent.com/83218752/119345423-257e8980-bc99-11eb-9054-712752305cbb.png">
