### PR TITLE
fix(Filters): remove preventing default in components

### DIFF
--- a/src/components/Filters/components/Input/Input.tsx
+++ b/src/components/Filters/components/Input/Input.tsx
@@ -73,12 +73,6 @@ const Input: React.FC<InputProps> = ({
     handleOnValidate(event);
   };
 
-  const handleKeyPress = (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-    }
-  };
-
   return (
     <>
       <StyledInput
@@ -90,7 +84,6 @@ const Input: React.FC<InputProps> = ({
         value={value}
         onBlur={handleOnValidate}
         onChange={handleOnChange}
-        onKeyPress={handleKeyPress}
       />
       {isInvalid && <Error>{errorMessage}</Error>}
     </>

--- a/src/components/Filters/components/Number/Number.tsx
+++ b/src/components/Filters/components/Number/Number.tsx
@@ -26,12 +26,6 @@ const Number: React.FC<NumberProps> = ({
   isInvalid = false,
   onError,
 }) => {
-  const handleKeyPress = (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-    }
-  };
-
   const handleOnChange = (event) => {
     onChange(event);
     const hasError =
@@ -49,7 +43,6 @@ const Number: React.FC<NumberProps> = ({
         type="number"
         value={value}
         onChange={handleOnChange}
-        onKeyPress={handleKeyPress}
       />
       {isInvalid && <Error>{errorMessage}</Error>}
     </>

--- a/src/components/Filters/components/Select/Select.tsx
+++ b/src/components/Filters/components/Select/Select.tsx
@@ -23,24 +23,15 @@ const MultiValue: React.FC<MultiValueProps<OptionTypeBase>> = (props) => {
   return <Tag value={data.label} onClose={removeProps.onClick} />;
 };
 
-const Select: React.FC<SelectProps> = (props) => {
-  const handleKeyPress = (event) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-    }
-  };
-
-  return (
-    <ReactSelect
-      components={{ DropdownIndicator, MultiValue }}
-      isClearable={false}
-      maxMenuHeight={163} // 5 menu options
-      styles={selectStyles}
-      onKeyDown={handleKeyPress}
-      {...props}
-    />
-  );
-};
+const Select: React.FC<SelectProps> = (props) => (
+  <ReactSelect
+    components={{ DropdownIndicator, MultiValue }}
+    isClearable={false}
+    maxMenuHeight={163} // 5 menu options
+    styles={selectStyles}
+    {...props}
+  />
+);
 
 export default Select;
 


### PR DESCRIPTION
We missed this when refactoring Filters from `form` to `div` container. There is no need to keep it there, moreover it was preventing selection in dropdown on enter.