### PR TITLE
feat(Table): reset pagination after sort and filter

### DIFF
--- a/src/components/Datatable/ControlsModule/ControlsModule.tsx
+++ b/src/components/Datatable/ControlsModule/ControlsModule.tsx
@@ -161,6 +161,7 @@ const ControlsModule = <D extends Record<string, unknown>>({
     });
 
     DatatableStore.update((s) => {
+      s.pageIndex = 0;
       s.filters = appliedfilters;
       s.hasAppliedFilters = hasAppliedFilters;
     });

--- a/src/components/Datatable/Table/Table.reducer.ts
+++ b/src/components/Datatable/Table/Table.reducer.ts
@@ -8,7 +8,6 @@ type StateReducerFn<D extends Record<string, unknown>> = (
 export const actions = {
   deselectAllRows: 'deselectAllRows',
   toggleSingleRowSelected: 'toggleSingleRowSelected',
-  reloadData: 'reloadData',
 };
 
 export const tableActionsReducer = <D extends Record<string, unknown>>({

--- a/src/components/Datatable/Table/Table.reducer.ts
+++ b/src/components/Datatable/Table/Table.reducer.ts
@@ -8,6 +8,7 @@ type StateReducerFn<D extends Record<string, unknown>> = (
 export const actions = {
   deselectAllRows: 'deselectAllRows',
   toggleSingleRowSelected: 'toggleSingleRowSelected',
+  reloadData: 'reloadData',
 };
 
 export const tableActionsReducer = <D extends Record<string, unknown>>({
@@ -22,7 +23,6 @@ export const tableActionsReducer = <D extends Record<string, unknown>>({
   const { pageIndex, pageSize, sortBy } = newState;
 
   switch (action.type) {
-    case 'gotoPage':
     case 'toggleSortBy':
       collectFetchParams(pageIndex, pageSize, sortBy);
       break;

--- a/src/components/Datatable/Table/Table.reducer.ts
+++ b/src/components/Datatable/Table/Table.reducer.ts
@@ -20,11 +20,11 @@ export const tableActionsReducer = <D extends Record<string, unknown>>({
     sortBy: SortingRule<D>[],
   ) => void;
 }): StateReducerFn<D> => (newState, action): TableState<D> => {
-  const { pageIndex, pageSize, sortBy } = newState;
+  const { pageSize, sortBy } = newState;
 
   switch (action.type) {
     case 'toggleSortBy':
-      collectFetchParams(pageIndex, pageSize, sortBy);
+      collectFetchParams(0, pageSize, sortBy);
       break;
     case actions.deselectAllRows:
       return { ...newState, selectedRowIds: {} };


### PR DESCRIPTION
 # Reset pagination when filters or sorting has changed

## changes
 - due to having to support both client/server side pagination we have two distinct states for pageIndex and because of this, we had to have the ability to change the page without side effects (`gotoPage` from `react-use-table`) in case the the page number has been changed elsewhere (e.g. filters which is outside the scope of `Table`). 
 - when `sortBy` changes reset page index to 0
 - when applying filters reset page index to 0