### PR TITLE
fix(fep-1808): tags are not removed after click on clearall

### DIFF
--- a/src/components/Filters/components/Select/Select.tsx
+++ b/src/components/Filters/components/Select/Select.tsx
@@ -5,6 +5,7 @@ import ReactSelect, {
   OptionTypeBase,
   components,
 } from 'react-select';
+import { toString } from 'ramda';
 
 import Tag from '../TagsInput/Tag';
 import { IconTypes, SSCIconNames } from '../../../../theme/icons/icons.enums';
@@ -23,20 +24,26 @@ const MultiValue: React.FC<MultiValueProps<OptionTypeBase>> = (props) => {
   return <Tag value={data.label} onClose={removeProps.onClick} />;
 };
 
-const Select: React.FC<SelectProps> = (props) => (
-  <ReactSelect
-    components={{ DropdownIndicator, MultiValue }}
-    isClearable={false}
-    maxMenuHeight={163} // 5 menu options
-    styles={selectStyles}
-    {...props}
-  />
-);
+const Select: React.FC<SelectProps> = (props) => {
+  const { value } = props;
+
+  return (
+    <ReactSelect
+      key={toString(value)}
+      components={{ DropdownIndicator, MultiValue }}
+      isClearable={false}
+      maxMenuHeight={163} // 5 menu options
+      styles={selectStyles}
+      {...props}
+    />
+  );
+};
 
 export default Select;
 
 Select.propTypes = {
   options: PropTypes.arrayOf(OptionPropType),
+  value: OptionPropType,
   defaultValue: PropTypes.oneOfType([
     OptionPropType,
     PropTypes.arrayOf(OptionPropType),


### PR DESCRIPTION
Problem: Tags are not removed from the select field if the multi-select field is in the first position and "condition" is the same as the default. (example: "detection method" first in the list). 

Solved by adding a "key" to select elements.

I'm not sure if it's the best solution. I'm open to any better suggestions.