### PR TITLE
feat(Tabs): add custom pattern matching for selected tab

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -45,9 +45,11 @@ const Tab: React.FC<TabProps> = ({
       $color={color}
       $isSelected={isSelected}
       $variant={variant}
+      aria-selected={isSelected}
       as={isLink ? RouterLink : 'a'}
       paddingSize={paddingSize}
       paddingType={PaddingTypes.squish}
+      role="tab"
       size={size}
       tabIndex={0}
       {...handler}

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { startsWith } from 'ramda';
+
+import { renderWithProviders } from '../../utils/tests/renderWithProviders';
+import Tab from './Tab';
+import Tabs from './Tabs';
+
+describe('Tabs', () => {
+  it('should determine selected tab by strict equality by default', () => {
+    renderWithProviders(
+      <Tabs selectedValue="overview">
+        <Tab value="overview/section">Overview section</Tab>
+        <Tab value="overview">Overview</Tab>
+      </Tabs>,
+    );
+
+    expect(
+      screen.queryByRole('tab', { name: /Overview/, selected: true }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('tab', {
+        name: /Overview section/,
+        selected: false,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should determine selected tab by custom pattern matcher if provided', () => {
+    renderWithProviders(
+      <Tabs
+        selectedValue="overview/section"
+        selectedPatternMatcher={startsWith}
+      >
+        <Tab value="section">Section</Tab>
+        <Tab value="overview">Overview</Tab>
+      </Tabs>,
+    );
+
+    expect(
+      screen.queryByRole('tab', { name: /Overview/, selected: true }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('tab', {
+        name: /Section/,
+        selected: false,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import { equals } from 'ramda';
 
 import { Inline, Padbox } from '../layout';
 import { TabsProps, Variants } from './Tabs.types';
@@ -32,6 +33,7 @@ const LabelList = styled(Padbox)<{
 
 const Tabs: React.FC<TabsProps> = ({
   selectedValue,
+  selectedPatternMatcher = equals,
   children,
   onSelectTab,
   size = TabSizes.sm,
@@ -50,6 +52,7 @@ const Tabs: React.FC<TabsProps> = ({
           gap={
             variant === TabVariants.segmented ? SpaceSizes.sm : SpaceSizes.lg
           }
+          role="tablist"
         >
           {React.Children.map(children, (tab) => {
             if (!React.isValidElement(tab)) {
@@ -60,7 +63,10 @@ const Tabs: React.FC<TabsProps> = ({
               size,
               variant,
               key: tab.props.value,
-              isSelected: tab.props.value === selectedValue,
+              isSelected: selectedPatternMatcher(
+                tab.props.value,
+                selectedValue,
+              ),
               onClick: onSelectTab,
             });
           })}
@@ -77,6 +83,7 @@ Tabs.propTypes = {
   size: PropTypes.oneOf(Object.values(TabSizes)),
   variant: PropTypes.oneOf(Object.values(TabVariants)),
   margin: SpacingSizeValuePropType,
+  selectedPatternMatcher: PropTypes.func,
   onSelectTab: PropTypes.func,
 };
 

--- a/src/components/Tabs/Tabs.types.ts
+++ b/src/components/Tabs/Tabs.types.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Colors } from '../../theme/colors.types';
 import { SpacingProps } from '../../types/spacing.types';
 import { PadboxProps } from '../layout/Padbox/Padbox';
@@ -16,8 +18,8 @@ export interface TabProps {
   children: React.ReactNode;
   color?: LabelProps['$color'];
   isSelected?: LabelProps['$isSelected'];
-  onClick?: (selectedValue: string | number) => void;
-  value: number | string;
+  onClick?: (selectedValue: React.ReactText) => void;
+  value: React.ReactText;
   size?: Sizes;
   variant?: LabelProps['$variant'];
 }
@@ -25,7 +27,11 @@ export interface TabProps {
 export interface TabsProps extends SpacingProps {
   size?: TabProps['size'];
   variant?: LabelProps['$variant'];
-  selectedValue: string | number;
-  onSelectTab?: (selectedValue: string | number) => void;
+  selectedValue: React.ReactText;
+  selectedPatternMatcher?: (
+    value: React.ReactText,
+    selectedValue: React.ReactText,
+  ) => boolean;
+  onSelectTab?: (selectedValue: React.ReactText) => void;
   children: React.ReactNode[];
 }


### PR DESCRIPTION
This PR adds an option to pass custom pattern matching predicate to determine which tab is currently selected. 
By default, the currently selected tab is determined by strict equality between `selectedValue` and Tab `value`. 
But we can provide for example `R.startsWith` as a predicate and in that case, when we have `selectedValue = "overview/section"` then Tab with `value= "overview"` will be marked as selected.