### PR TITLE
fix(SearchBar): run search if validated

### DIFF
--- a/src/components/forms/SearchBar/SearchBar.tsx
+++ b/src/components/forms/SearchBar/SearchBar.tsx
@@ -123,6 +123,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
     const { target } = event;
     const hasError = validatePattern(target) && isNonEmptyString(target.value);
     setInvalid(hasError);
+    return hasError;
   };
 
   const handleChangeQuery = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -131,7 +132,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
     if (!isNonEmptyString(newQuery)) {
       clearSearch();
     }
-    if (!isValidatedOnSubmit) {
+    if (!isValidatedOnSubmit || isInvalid) {
       handleOnValidate(event);
     }
     if (hasSuggestions) {
@@ -141,10 +142,10 @@ const SearchBar: React.FC<SearchBarProps> = ({
 
   const handleKeyDown = (event) => {
     if (event.key === 'Enter') {
-      if (isValidatedOnSubmit) {
-        handleOnValidate(event);
+      const hasError = handleOnValidate(event);
+      if (!hasError) {
+        search(query);
       }
-      search(query);
     }
   };
 


### PR DESCRIPTION
The issue: With `isValidatedOnSubmit: true` the `onSearch` function was being called even when the input is invalid because `handleOnValidate` was adding the error status in the state variable `isInvalid` which was not updated before submit

Solution: Run validation on every submit and return `hasError` status directly from `handleOnValidate` to check before searching