### PR TITLE
fix(primitives): prevent passing 'undefined' into CSS

### DIFF
--- a/src/components/layout/Cluster/Cluster.tsx
+++ b/src/components/layout/Cluster/Cluster.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import PropTypes, { ReactComponentLike } from 'prop-types';
 import { Property } from 'csstype';
 
@@ -47,7 +47,7 @@ const ClusterParent = styled.div<ClusterParentProps>(
   ({ $gap, $justify, $align, theme }) => {
     const gapSize = getSpace($gap, { theme });
 
-    return `
+    return css`
       display: flex;
       flex-wrap: wrap;
       justify-content: ${$justify};

--- a/src/components/layout/Grid/Grid.tsx
+++ b/src/components/layout/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import PropTypes, { ReactComponentLike } from 'prop-types';
 import { Property } from 'csstype';
 
@@ -44,7 +44,7 @@ const GridParent = styled.div<GridParentProps>(
   ({ $cols, $gap, $align, theme }) => {
     const gapSize = getSpace($gap, { theme });
 
-    return `
+    return css`
       display: flex;
       flex-wrap: wrap;
       align-items: ${$align};


### PR DESCRIPTION
The `css` function filters out falsy values if is not used `undefined` value is converted to a string and then passed as an invalid value into CSS. The `css` function filters out falsy values.