### PR TITLE
fix(Modal): close button bg, portal removal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -74,6 +74,7 @@ const CloseButton = styled.button`
   flex-shrink: 0;
   border: none;
   cursor: pointer;
+  background-color: transparent;
   color: ${getColor('graphite3B')};
 `;
 
@@ -92,6 +93,7 @@ const Modal = forwardRef<HTMLDivElement, ModalProps>(
     const { Portal } = usePortal({
       containerId: portalsContainerId,
       internalShowHide: false,
+      autoRemoveContainer: false,
     });
     const hasFooter = isNotUndefined(footer);
 


### PR DESCRIPTION
- CloseButton on Modal was inheriting browser button bg color, which was manifesting when using modal without css reset.
- Modal was removing portal container on unmount, which was causing style mismatch on next mount.