### PR TITLE
fix(DataTable): set default values in datatable reducer

### DIFF
--- a/src/components/Datatable/Table/Table.tsx
+++ b/src/components/Datatable/Table/Table.tsx
@@ -277,6 +277,14 @@ TableProps<D>): React.ReactElement => {
     collectSelectedIds<D>(selectedRowIds);
   }, [selectedRowIds]);
 
+  useEffect(() => {
+    DatatableStore.update((s) => {
+      s.pageIndex = defaultPageIndex;
+      s.sortBy = defaultSortBy;
+      s.pageSize = defaultPageSize;
+    });
+  }, [defaultPageIndex, defaultSortBy, defaultPageSize]);
+
   return (
     <>
       <TableAndLoadingOverlayContainer>


### PR DESCRIPTION
In order to support initial values for sorting, page size, and index when searching we need to set those values in the store straight away to avoid them being overwritten by defaults.