### PR TITLE
fix(Banner): close button background reset

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -80,6 +80,7 @@ const CloseButton = styled.button`
   border: none;
   flex-shrink: 0;
   cursor: pointer;
+  background-color: transparent;
   color: ${getColor('graphite3B')};
   width: ${pxToRem(16)};
   height: ${pxToRem(16)};


### PR DESCRIPTION
The close button on Banner component gets rendered with a light gray background when used without explicit resets. This forces it to have transparent background.