### PR TITLE
refactor(utils): remove getBorderRadius helper method

### DIFF
--- a/src/components/Filters/components/DateRangePicker/styles.ts
+++ b/src/components/Filters/components/DateRangePicker/styles.ts
@@ -2,12 +2,12 @@ import { css } from 'styled-components';
 import { transparentize } from 'polished';
 
 import {
-  getBorderRadius,
   getColor,
   getFontSize,
   getFontWeight,
   getFormStyle,
   getLineHeight,
+  getRadii,
   pxToRem,
 } from '../../../../utils';
 
@@ -17,7 +17,7 @@ export const datePickerStyles = css`
     padding: ${pxToRem(4, 16)};
     background: ${getFormStyle('bgColor')};
     border: ${getFormStyle('borderWidth')} solid ${getFormStyle('borderColor')};
-    border-radius: ${getBorderRadius};
+    border-radius: ${getRadii('default')};
     color: ${getFormStyle('color')};
     font-size: ${getFontSize('md')};
     line-height: ${getLineHeight('md')};
@@ -41,7 +41,7 @@ export const datePickerStyles = css`
     line-height: ${getLineHeight('md')};
     font-weight: ${getFontWeight('regular')};
     padding: ${pxToRem(16)};
-    border-radius: ${getBorderRadius};
+    border-radius: ${getRadii('default')};
     box-shadow: 0 2px 6px 0 ${transparentize(0.85, '#000')};
     background: ${getColor('neutral.0')};
   }

--- a/src/utils/helpers.stories.mdx
+++ b/src/utils/helpers.stories.mdx
@@ -209,22 +209,6 @@ const Component = styled.div`
 `; // -> line-height: 20px;
 ```
 
-### getBorderRadius (DEPRECATED)
-
-Use `getRadii` function instead.
-
-Returns default border-radius from theme.
-
-```js
-import { getBorderRadius } from '@securityscorecard/design-system';
-
-// getBorderRadius :: Props -> string
-// Props - styled-components props object
-const Component = styled.div`
-  border-radius: ${getBorderRadius};
-`; // -> border-radius: 4px;
-```
-
 ### getRadii
 
 Returns border-radius from theme for given key.

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,11 +1,6 @@
 import { getRadii } from '.';
 import { ColorTypes, RadiusTypes, theme } from '../theme';
-import {
-  abbreviateNumber,
-  getBorderRadius,
-  getColor,
-  pxToRem,
-} from './helpers';
+import { abbreviateNumber, getColor, pxToRem } from './helpers';
 
 describe('pxToRem', () => {
   it('should not convert 0 value', () => {
@@ -73,12 +68,6 @@ describe('getColor', () => {
     expect(getColor(ColorTypes.graphite3H, { theme })).toBe('#f3f3f3');
     expect(getColor(ColorTypes.graphite4H, { theme })).toBe('#f9f9f9');
     expect(getColor(ColorTypes.graphite5H, { theme })).toBe('#fff');
-  });
-});
-
-describe('getBorderRadius', () => {
-  it('should return correct value', () => {
-    expect(getBorderRadius({ theme })).toBe('4px');
   });
 });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -91,10 +91,6 @@ export const getLineHeight = curry(
     path(['typography', 'lineHeight', size], theme),
 );
 
-// getBorderRadius :: Props -> string
-// Props - styled-components props object
-export const getBorderRadius = path(['theme', 'radii', 'default']);
-
 // getRadii :: Type -> Props -> string
 // Type - any key of 'radii' (src/theme/radii.ts)
 // Props - styled-components props object


### PR DESCRIPTION
This PR removes getBorderRadius method from DS codebase. 

[Closes](https://zitenote.atlassian.net/browse/UXD-393)