### PR TITLE
feat(Datatable): add option to control state

### DIFF
--- a/src/components/Datatable/Table/Table.tsx
+++ b/src/components/Datatable/Table/Table.tsx
@@ -4,7 +4,9 @@ import {
   CellProps,
   Column,
   IdType,
+  MetaBase,
   SortingRule,
+  TableState,
   useColumnOrder,
   useFlexLayout,
   usePagination,
@@ -95,8 +97,15 @@ const Table = <D extends Record<string, unknown>>({
   defaultSortBy,
   defaultPageIndex,
   defaultColumnOrder,
+  ...rest
 }: // defaultHiddenColumns,
 TableProps<D>): React.ReactElement => {
+  const { useControlledState } = rest as TableProps<D> & {
+    useControlledState: (
+      state: TableState<D>,
+      meta: MetaBase<D>,
+    ) => TableState<D>;
+  };
   const tableDataSize = useMemo(
     () => (hasServerSidePagination ? dataSize : data.length),
     [hasServerSidePagination, dataSize, data],
@@ -174,6 +183,7 @@ TableProps<D>): React.ReactElement => {
       rowActions,
       dataSize: tableDataSize,
       isMultiSelect,
+      useControlledState,
     },
     useColumnOrder,
     useSortBy,

--- a/src/components/Datatable/Table/Table.types.ts
+++ b/src/components/Datatable/Table/Table.types.ts
@@ -13,7 +13,7 @@ export type OnSelectFn<D> = (
   hasExclusiveSelection: boolean,
 ) => void;
 
-export interface TableConfig<D> {
+export interface TableConfig<D extends Record<string, unknown>> {
   hasSelection: boolean;
   isDataLoading: boolean;
   isMultiSelect: boolean;


### PR DESCRIPTION
This PR add option to manually control Datatable state from outside.
For more info https://react-table.tanstack.com/docs/faq#how-can-i-manually-control-the-table-state