### PR TITLE
fix(Breadcrumbs): fix order and options showed in dropdown

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -68,7 +68,7 @@ describe('Breadcrumbs', () => {
     expect(screen.getByText(/Parent4/i)).toBeVisible();
   });
 
-  it('should show all items within dropdown in reversed order ', () => {
+  it('should show items within dropdown using correct order ', () => {
     renderWithProviders(
       <Breadcrumbs>
         <BreadcrumbItem href="#">Link1</BreadcrumbItem>
@@ -88,8 +88,8 @@ describe('Breadcrumbs', () => {
 
     // Check reverse index for links within the dropdown
     const links = screen.queryAllByText('Link', { exact: false });
-    expect(links.findIndex((item) => item.textContent === 'Link1')).toBe(6);
-    expect(links.findIndex((item) => item.textContent === 'Link9')).toBe(0);
+    expect(links.findIndex((item) => item.textContent === 'Link5')).toBe(3);
+    expect(links.findIndex((item) => item.textContent === 'Link2')).toBe(0);
   });
 
   it('should be the last breadcrumb item not a link', () => {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { reverse, slice } from 'ramda';
+import { slice } from 'ramda';
 import styled from 'styled-components';
 import { isNilOrEmpty, isNotNilOrEmpty } from 'ramda-adjunct';
 
@@ -98,8 +98,11 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ children, ...props }) => {
     });
   });
 
-  const allDropdownActions = reverse(
-    React.Children.map(children, (breadcrumbItem) => {
+  const allDropdownActions = slice(
+    1,
+    -2,
+  )(
+    React.Children.toArray(children).map((breadcrumbItem) => {
       if (!React.isValidElement(breadcrumbItem)) {
         return null;
       }


### PR DESCRIPTION
We decided to change the order of the elements in breadcrumb overflow-dropdown not to be in reverse order. Also, dropdown options list only show the hidden elements, not all breadcrumb items. 


[Closes](https://zitenote.atlassian.net/browse/UXD-211)