### PR TITLE
fix(Datatable): reset selection on data change

### DIFF
--- a/src/components/Datatable/Table/Table.tsx
+++ b/src/components/Datatable/Table/Table.tsx
@@ -16,6 +16,7 @@ import {
   allPass,
   any,
   equals,
+  isEmpty,
   keys,
   pick,
   pipe,
@@ -195,6 +196,12 @@ TableProps<D>): React.ReactElement => {
     gotoPage(newPageIndex);
     collectFetchParams(newPageIndex, pageSize, sortBy);
   };
+
+  useEffect(() => {
+    if (isEmpty(defaultSelectedRows)) {
+      dispatch({ type: actions.deselectAllRows });
+    }
+  }, [defaultSelectedRows, dispatch]);
 
   useEffect(() => {
     const unsubscribe = DatatableStore.subscribe(


### PR DESCRIPTION
Currently, when any manipulation with data happens (e.g. row is removed), selected row IDs stay selected after that. This PR adds a selection reset whenever table data changes.

Closes UXD-295