### PR TITLE
fix(SegmentedToggle): fix hover-pressed state colors

### DIFF
--- a/src/components/_internal/BaseTabs/BaseTabLabel.tsx
+++ b/src/components/_internal/BaseTabs/BaseTabLabel.tsx
@@ -119,7 +119,11 @@ const segmentedTab = css<BaseLabelProps & { size: Sizes }>`
   color: ${getColor('neutral.900')};
 
   &:hover {
-    color: ${getColor('primary.400')};
+    color: ${getColor('primary.600')};
+  }
+
+  &:active {
+    color: ${getColor('primary.700')};
   }
 `;
 


### PR DESCRIPTION
Update hover and pressed state color in Segmented Toggle

[Closes](https://zitenote.atlassian.net/browse/UXD-550)