### PR TITLE
build: remove Node@12 tests

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ['14', '16', '18']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
@@ -28,10 +28,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-${{ matrix.node }}-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-${{ matrix.node }}-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install Packages
         if: steps.cache.outputs.cache-hit != 'true'
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -58,10 +58,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-16-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-16-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-16-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install Packages
         if: steps.cache.outputs.cache-hit != 'true'
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -88,10 +88,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-16-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-16-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-16-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install Packages
         if: steps.cache.outputs.cache-hit != 'true'
@@ -111,17 +111,16 @@ jobs:
       - name: Run Visual Regressions
         run: yarn test:storybook:visual:ci
 
+      - name: Tar artifacts
+        if: failure()
+        run: tar -cvf visual-test-reports.tar .storybook/image-snapshots
+
       - name: Archive visual artifacts
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v2
         with:
           name: visual-test-reports
-          path: |
-            .storybook/image-snapshots/actual/*
-            .storybook/image-snapshots/diff/*
-            .storybook/image-snapshots/expected/*
-            .storybook/image-snapshots/report.html
-            .storybook/image-snapshots/report.json
+          path: visual-test-reports.tar
 
   lint:
     runs-on: ubuntu-latest
@@ -130,7 +129,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -141,10 +140,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-16-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-16-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-16-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install Packages
         if: steps.cache.outputs.cache-hit != 'true'
@@ -160,7 +159,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -171,10 +170,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-16-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-16-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-16-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install Packages
         if: steps.cache.outputs.cache-hit != 'true'
@@ -190,7 +189,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
@@ -201,9 +200,9 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-16-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-16-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-16-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install Packages
         if: steps.cache.outputs.cache-hit != 'true'
@@ -216,17 +215,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ['14', '16', '18']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@securityscorecard'
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -235,10 +232,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-${{ matrix.node }}-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-${{ matrix.node }}-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install Packages
         if: steps.cache.outputs.cache-hit != 'true'
@@ -254,6 +251,11 @@ jobs:
       - name: Build Step
         run: yarn build
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: bundle-stats-${{ matrix.node }}
+          path: stats
+
   build-and-publish:
     if: "github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/alpha') && !contains(github.event.head_commit.message, 'chore(release):')"
     needs: [unit-tests, visual-tests, types, lint, lint-css, betterer, build]
@@ -263,7 +265,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
           registry-url: 'https://registry.npmjs.org'
@@ -276,10 +278,10 @@ jobs:
           path: node_modules
           key: ${{ runner.os }}-node-16-${{ hashFiles('**/yarn.lock', '**/package.json') }}
           restore-keys: |
-            ${{ runner.OS }}-node-16-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-${{ env.cache-name }}-
-            ${{ runner.OS }}-node-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-node-16-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
       - name: Install Packages
         if: steps.cache.outputs.cache-hit != 'true'
@@ -295,11 +297,6 @@ jobs:
       - name: Build Step
         if: steps.library-build-cache.outputs.cache-hit != 'true'
         run: yarn build
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: bundle-stats
-          path: stats
 
       - name: Run Semantic Release
         run: yarn semantic-release

--- a/package.json
+++ b/package.json
@@ -82,6 +82,12 @@
     "@rollup/plugin-commonjs": "^21.0.3",
     "@rollup/plugin-node-resolve": "^13.2.0",
     "@rollup/plugin-url": "^6.1.0",
+    "@semantic-release/changelog": "^6.0.1",
+    "@semantic-release/commit-analyzer": "^9.0.2",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^8.0.4",
+    "@semantic-release/npm": "^9.0.1",
+    "@semantic-release/release-notes-generator": "^10.0.3",
     "@storybook/addon-a11y": "^6.4.22",
     "@storybook/addon-actions": "^6.4.22",
     "@storybook/addon-backgrounds": "^6.4.22",
@@ -136,6 +142,7 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
     "rollup-plugin-visualizer": "^5.6.0",
+    "semantic-release": "^19.0.2",
     "storybook-addon-designs": "^6.2.1",
     "storybook-addon-outline": "^1.4.2",
     "storycap": "3.0.4",
@@ -147,15 +154,6 @@
     "ts-jest": "^27.1.4",
     "tslib": "^2.3.1",
     "typescript": "^4.6.2"
-  },
-  "optionalDependencies": {
-    "@semantic-release/changelog": "^6.0.1",
-    "@semantic-release/commit-analyzer": "^9.0.2",
-    "@semantic-release/git": "^10.0.1",
-    "@semantic-release/github": "^8.0.4",
-    "@semantic-release/npm": "^9.0.1",
-    "@semantic-release/release-notes-generator": "^10.0.3",
-    "semantic-release": "^19.0.2"
   },
   "resolutions": {
     "trim": "1.0.1",


### PR DESCRIPTION
* replaces Node@12 with Node@18
* upgrades `actions/setup-node` to latest version
* fix some typing inconsistencies
* add uploading bundle stats during the build step
* change handling of visual regression artifacts (tar before upload and upload only when test fails)
* move semantic release back to dev deps to prevent leaking in the consumer's yarn.lock (this was done because installing was filing when used with Node@12) 