### PR TITLE
chore(types): add support for polymorphic components

### DIFF
--- a/src/types/polymorphicComponent.types.ts
+++ b/src/types/polymorphicComponent.types.ts
@@ -1,0 +1,64 @@
+import React from 'react';
+
+/**
+ * This code is taken from two articles written by Ben Ilegbodu (https://github.com/benmvp)
+ * https://www.benmvp.com/blog/polymorphic-react-components-typescript/
+ * https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/
+ */
+
+// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
+// A more precise version of just React.ComponentPropsWithoutRef on its own
+type PropsOf<
+  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<unknown>,
+> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
+
+type AsProp<C extends React.ElementType> = {
+  /**
+   * An override of the default HTML tag.
+   * Can also be another React component.
+   */
+  as?: C;
+};
+
+/**
+ * Allows for extending a set of props (`ExtendedProps`) by an overriding set of props
+ * (`OverrideProps`), ensuring that any duplicates are overridden by the overriding
+ * set of props.
+ */
+type ExtendableProps<
+  ExtendedProps = Record<string, unknown>,
+  OverrideProps = Record<string, unknown>,
+> = OverrideProps & Omit<ExtendedProps, keyof OverrideProps>;
+
+/**
+ * Allows for inheriting the props from the specified element type so that
+ * props like children, className & style work, as well as element-specific
+ * attributes like aria roles. The component (`C`) must be passed in.
+ */
+type InheritableElementProps<
+  C extends React.ElementType,
+  Props = Record<string, unknown>,
+> = ExtendableProps<PropsOf<C>, Props>;
+
+/**
+ * A more sophisticated version of `InheritableElementProps` where
+ * the passed in `as` prop will determine which props can be included
+ */
+export type PolymorphicComponentProps<
+  C extends React.ElementType,
+  Props = Record<string, unknown>,
+> = InheritableElementProps<C, Props & AsProp<C>>;
+
+/**
+ * Utility type to extract the `ref` prop from a polymorphic component
+ */
+export type PolymorphicRef<C extends React.ElementType> =
+  React.ComponentPropsWithRef<C>['ref'];
+/**
+ * A wrapper of `PolymorphicComponentProps` that also includes the `ref`
+ * prop for the polymorphic component
+ */
+export type PolymorphicComponentPropsWithRef<
+  C extends React.ElementType,
+  Props = Record<string, unknown>,
+> = PolymorphicComponentProps<C, Props> & { ref?: PolymorphicRef<C> };


### PR DESCRIPTION
This PR adds types to support polymorphic component props checking. For more info please follow:
https://www.benmvp.com/blog/polymorphic-react-components-typescript/
https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/