### PR TITLE
feat(Searchbar): set new icon positions for SearchBar

### DIFF
--- a/src/components/forms/SearchBar/SearchBar.tsx
+++ b/src/components/forms/SearchBar/SearchBar.tsx
@@ -176,17 +176,14 @@ const SearchBar: React.FC<SearchBarProps> = ({
 
   return (
     <SearchBarWrapper {...props}>
-      {isNonEmptyString(query) ? (
-        <SearchBarIcon
-          $position="start"
-          aria-label="Clear Search"
-          as={ClearSearchButton}
-          onClick={clearSearch}
-        >
-          <Icon
-            color={ColorTypes.neutral700}
-            name={SSCIconNames.times}
-            type={IconTypes.ssc}
+      {isSearching ? (
+        <SearchBarIcon $position="start">
+          <Spinner
+            borderWidth={2}
+            height={16}
+            verticalMargin={0}
+            width={16}
+            dark
           />
         </SearchBarIcon>
       ) : (
@@ -214,14 +211,17 @@ const SearchBar: React.FC<SearchBarProps> = ({
       />
       {isInvalid && <Error>{errorMessage}</Error>}
 
-      {isSearching && (
-        <SearchBarIcon $position="end">
-          <Spinner
-            borderWidth={2}
-            height={16}
-            verticalMargin={0}
-            width={16}
-            dark
+      {isNonEmptyString(query) && (
+        <SearchBarIcon
+          $position="end"
+          aria-label="Clear Search"
+          as={ClearSearchButton}
+          onClick={clearSearch}
+        >
+          <Icon
+            color={ColorTypes.neutral700}
+            name={SSCIconNames.times}
+            type={IconTypes.ssc}
           />
         </SearchBarIcon>
       )}


### PR DESCRIPTION
This PR changes the icon positions for SearchBar. 
Basically: 

- I’ve updated the search bar component design as follows
- the search icon is on the left
- when the field has input, a clear button appears on right while processing, and the search icon is replaced by a loading spinner

