### PR TITLE
fix(Button): change focus state behaviour

### DIFF
--- a/src/components/_internal/BaseButton/BaseStyledButton.tsx
+++ b/src/components/_internal/BaseButton/BaseStyledButton.tsx
@@ -89,7 +89,7 @@ const ButtonSolid = css<BaseStyledButtonProps>`
             color: ${getButtonColor('color')};
             text-decoration: none;
           }
-          &:focus:not(:disabled),
+          &:focus-visible:not(:disabled),
           &.focus {
             background-color: ${getButtonColor('hoverBgColor')};
             border-color: ${getButtonColor('hoverBgColor')};
@@ -136,7 +136,7 @@ const ButtonOutline = css<BaseStyledButtonProps>`
             color: ${getButtonColor('color')};
             text-decoration: none;
           }
-          &:focus:not(:disabled),
+          &:focus-visible:not(:disabled),
           &.focus {
             background-color: ${getButtonColor('hoverBgColor')};
             color: ${getButtonColor('color')};
@@ -180,7 +180,7 @@ const ButtonText = css<BaseStyledButtonProps>`
             color: ${getButtonColor('hoverColor')};
             text-decoration: none;
           }
-          &:focus:not(:disabled),
+          &:focus-visible:not(:disabled),
           &.focus {
             background-color: ${getButtonColor('focusBgColor')};
             border-color: ${getButtonColor('focusBgColor')};
@@ -231,7 +231,7 @@ const BaseStyledButton = styled.button.withConfig<BaseStyledButtonProps>({
 
   ${({ margin }) => createMarginSpacing(margin)};
 
-  &:focus {
+  &:focus-visible {
     outline: 0;
   }
 

--- a/src/components/_internal/BaseSingleDatePicker/styles.ts
+++ b/src/components/_internal/BaseSingleDatePicker/styles.ts
@@ -90,7 +90,7 @@ export const datePickerStyles = css`
     font-weight: ${getFontWeight('bold')};
     color: ${getColor('neutral.0')};
   }
-  .react-datepicker__day:focus {
+  .react-datepicker__day:focus-visible {
     background-color: ${getColor('primary.600')};
     border-radius: 4px;
     font-weight: ${getFontWeight('bold')};
@@ -99,7 +99,7 @@ export const datePickerStyles = css`
     outline-offset: 2px;
     position: relative;
   }
-  .react-datepicker__day--in-range:focus {
+  .react-datepicker__day--in-range:focus-visible {
     outline: 2px solid ${getColor('primary.200')};
     outline-offset: 2px;
     position: relative;
@@ -235,9 +235,9 @@ export const singleDatePickerStyles = css`
     color: ${getColor('neutral.0')};
     border-radius: ${getRadii('default')};
   }
-  .react-datepicker__day--range-start:focus,
-  .react-datepicker__day--range-end:focus,
-  .react-datepicker__day--selected:focus {
+  .react-datepicker__day--range-start:focus-visible,
+  .react-datepicker__day--range-end:focus-visible,
+  .react-datepicker__day--selected:focus-visible {
     background-color: ${getColor('primary.600')};
     outline: 2px solid ${getColor('primary.200')};
     outline-offset: 2px;


### PR DESCRIPTION
This PR fixes the `:focus` to `:focus-visible` for the `Button` component and for the buttons at `DatePicker/DatePickerRange.` 

The rest of the components don't need an update because the usage of the focus is correct. 

[Closes](https://zitenote.atlassian.net/browse/UXD-636)