### PR TITLE
docs(Drawer): add code example for close handling

### DIFF
--- a/src/codeExamples/closeHandlingDrawer.stories.mdx
+++ b/src/codeExamples/closeHandlingDrawer.stories.mdx
@@ -1,0 +1,163 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta title="code examples/close handling for Drawer" />
+
+# Closing Drawer behaviour
+
+Even though the close handling for a [Drawer](?path=/docs/components-drawer--playground) might be implemented as a simple state change,
+sometimes it might be necessary to prevent the [Drawer](?path=/docs/components-drawer--playground) be closed until some action is finished.
+(e.g. uploading a file or saving a form).
+
+## Example 1
+
+Here is an example of how we usually handle the closing functionality:
+
+```jsx
+export const Component = (args) => {
+  const [isShown, setIsShown] = useState(false);
+
+  return (
+        {isShown && (
+          <Drawer
+            footer={<Footer />}
+            title="Title"
+            onClose={() => setIsShown(false)}
+            {...args}
+          >
+            <Content />
+          </Drawer>
+        )}
+  );
+};
+```
+
+## Example 2
+
+And here is an example of how to prevent a [Drawer](?path=/docs/components-drawer--playground) to be closed when there is an action running and you'll need to wait until it ends:
+
+```jsx
+export const Component = () => {
+  // state used for handling the show/hide Drawer
+  const [isShown, setIsShown] = useState(false);
+
+  // state used for enforce user to not close before the action completes
+  const [showForceCancel, setShowForceCancel] = useState(false);
+
+  // replace this condition with your custom condition to wait for something
+  const waitingForSomething = true;
+
+  // onClick handler when user attempts to close the Drawer
+  const handleClose = useCallback(() => {
+    if (waitingForSomething) {
+      // if the action is still running warn user
+      setShowForceCancel(true);
+    } else {
+      // if not close safely
+      setIsShown(false);
+    }
+  }, [waitingForSomething, setIsShown]);
+
+  return (
+      {isShown && (
+        <Drawer
+          footer={
+            showForceCancel ? (
+              <Stack gap="md">
+                <Text size="md">
+                  Your action is still in progress. You can continue waiting for
+                  the upload to complete or click cancel upload and leave this
+                  page.
+                </Text>
+                <Inline gap="md">
+                  <Button isExpanded onClick={() => setShowForceCancel(false)}>
+                    Wait for the action to complete
+                  </Button>
+                  <Button
+                    color="danger"
+                    isExpanded
+                    onClick={() => {
+                      setIsShown(false);
+                    }}
+                  >
+                    Cancel action before it completes
+                  </Button>
+                </Inline>
+              </Stack>
+            ) : (
+              <Stack justify="flex-end">
+                <Inline gap="md">
+                  <Button onClick={handleClose}>Cancel</Button>
+                  <Button
+                    isLoading={waitingForSomething}
+                    onClick={() => {
+                      // implement your action
+                      setIsShown(false);
+                    }}
+                  >
+                    Your action
+                  </Button>
+                </Inline>
+              </Stack>
+            )
+          }
+          onClose={handleClose}
+        >
+          Your Drawer content here
+        </Drawer>
+      )}
+  );
+};
+```
+
+## Example 3
+
+Here is another example of how to prevent a [Drawer](?path=/docs/components-drawer--playground) to be closed when there is an action running and you'll need to wait until it ends:
+
+```jsx
+export const Component = () => {
+  // state used for handling the show/hide Drawer
+  const [isShown, setIsShown] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [displayWarning, setDisplayWarning] = useState(false);
+  // onClick handler when user attempts to close the Drawer
+  let click = 0;
+  const handleClose = () => {
+    // on first
+    if (click === 0 && isProcessing) {
+        setDisplayWarning(true);
+        click ++;
+        return;
+    } else {
+        setIsShown(false);
+    }
+  };
+
+  return (
+      {isShown && (
+        <Drawer
+          footer={
+              <Stack justify="flex-end">
+                <Inline gap="md">
+                  // show warning if process is in progress
+                  {setDisplayWarning && <Paragraph>Saving changes is in progress</Paragraph>}
+                  <Button onClick={handleClose}>Cancel</Button>
+                  <Button
+                    isLoading={isProcessing}
+                    onClick={() => {
+                      // implement your action
+                      setIsShown(false);
+                    }}
+                  >
+                    Your action
+                  </Button>
+                </Inline>
+              </Stack>
+          }
+          onClose={handleClose}
+        >
+          Your Drawer content here
+        </Drawer>
+      )}
+  );
+};
+```


### PR DESCRIPTION
This PR adds a code example for close handling with `Drawer` component

[Closes](https://zitenote.atlassian.net/browse/UXD-651)