### PR TITLE
feat(Filters): expose onError callback

### DIFF
--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -74,5 +74,10 @@ export const WithCloseButton: Story = () => (
 );
 
 export const WithoutApplyButton: Story = () => (
-  <Filters fields={fields} state={state} onChange={action('onChange')} />
+  <Filters
+    fields={fields}
+    state={state}
+    onChange={action('onChange')}
+    onError={action('onError')}
+  />
 );

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -79,6 +79,7 @@ const Filters: React.FC<FiltersProps> = ({
   onChange = noop,
   onClose,
   onCancel = noop,
+  onError,
   isLoading = false,
   isCancelEnabled = true,
   isOperatorFieldEnabled = true,
@@ -146,6 +147,8 @@ const Filters: React.FC<FiltersProps> = ({
     newValidValues[index] = !hasError;
 
     setValidValues(newValidValues);
+
+    onError?.(hasError);
   };
 
   const hasInvalidValues = validValues.some((valid) => valid === false);

--- a/src/components/Filters/Filters.types.ts
+++ b/src/components/Filters/Filters.types.ts
@@ -62,6 +62,7 @@ export interface FiltersProps {
   onClose?: () => void;
   onCancel?: () => void;
   onChange?: (filters: Filter[]) => void;
+  onError?: (hasError: boolean) => void;
   isLoading?: boolean;
   isCancelEnabled?: boolean;
   isOperatorFieldEnabled?: boolean;
@@ -130,4 +131,5 @@ export const FiltersPropType = {
   onClose: PropTypes.func,
   onCancel: PropTypes.func,
   onChange: PropTypes.func,
+  onError: PropTypes.func,
 };


### PR DESCRIPTION
When Filters component is used without Apply button `onError` callback
can be used to determine state of submit button and prevent user from
sending invalid form data.
This callback is called on any change event and takes boolean `hasError`
as first argument.

Closes UXD-856