### PR TITLE
fix: changed line-height to 1rem in state button

### DIFF
--- a/src/components/Filters/StateButton/StateButton.tsx
+++ b/src/components/Filters/StateButton/StateButton.tsx
@@ -12,7 +12,6 @@ import {
   getDepth,
   getFontFamily,
   getFontWeight,
-  getLineHeight,
   getRadii,
   pxToRem,
 } from '../../../utils';
@@ -62,7 +61,7 @@ const RemoveButton = styled.button`
 
 const LightText = styled(Text)`
   color: ${getColor('neutral.0')};
-  line-height: ${getLineHeight('md')};
+  line-height: 1rem;
   font-weight: ${getFontWeight('medium')};
 `;
 


### PR DESCRIPTION
[Filters] StateButton line height is wrong, the padding exceeded the height in the text part of the button.

Before
<img width="982" alt="image" src="https://user-images.githubusercontent.com/102039894/193301608-9edca938-94f3-4555-ba68-9dd048c9c145.png">


After
<img width="969" alt="image" src="https://user-images.githubusercontent.com/102039894/193298222-e441eb66-7d40-45d3-b790-8781aafcd4ec.png">


https://zitenote.atlassian.net/browse/UXD-910