### PR TITLE
feat(bundle): externalize react-select dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^16.14.0",
     "react-is": ">= 16.8.0",
     "react-router-dom": "^5.2.0",
+    "react-select": "^4.3.1",
     "require-from-string": "^2.0.2",
     "styled-components": "^5.1.0"
   },
@@ -78,7 +79,6 @@
     "react-dropzone": "^12.1.0",
     "react-input-autosize": "^3.0.0",
     "react-popper": "^2.2.5",
-    "react-select": "^4.3.1",
     "react-table": "^7.7.0",
     "react-table-sticky": "^1.1.3",
     "reflexbox": "^4.0.6",
@@ -152,6 +152,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.3.0",
+    "react-select": "^4.3.1",
     "react-select-event": "^5.3.0",
     "react-test-renderer": "^16.13.1",
     "rollup": "^2.70.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,6 +22,11 @@ export default {
       sourcemap: true,
     },
   ],
+  external: [
+    'react-select/async',
+    'react-select/creatable',
+    'react-select/async-creatable',
+  ],
   plugins: [
     autoExternal(),
     resolve(),
@@ -33,7 +38,8 @@ export default {
     typescript({ useTsconfigDeclarationDir: true }),
     terser(),
     visualizer({
-      filename: `stats/stat.html`,
+      filename: 'stats/stat.html',
+      template: 'sunburst',
     }),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,6 +3514,7 @@ __metadata:
     react-dom: ^16.14.0
     react-is: ">= 16.8.0"
     react-router-dom: ^5.2.0
+    react-select: ^4.3.1
     require-from-string: ^2.0.2
     styled-components: ^5.1.0
   languageName: unknown


### PR DESCRIPTION
We will be able to save almost 30 % of bundle size with this (see images below). 

We were not externalizing the `react-select` before so as a first step I moved this dependency into `peerDependencies` as our users install `react-select` anyway in their products. This didn't help as RS was still leaking into the bundle. 

My investigation showed that the issue causing this was importing `react-select/creatable`, `react-select/async-creatable` and `react-select/async`. Unfortunately `rollup-plugin-auto-external` was not able to detect those as peer dependencies to externalize those automatically so it was needed to explicitly add those paths into the list of external dependencies.

### Screenshots

#### Before
<img width="193" alt="Screenshot 2022-10-03 at 18 23 02" src="https://user-images.githubusercontent.com/18654425/193630338-4b6b2923-b13f-4afb-acb6-4c68c2e05b28.png">
<img width="958" alt="Screenshot 2022-10-03 at 18 23 33" src="https://user-images.githubusercontent.com/18654425/193630340-9eb264c4-42c3-4542-957c-a1b63c98f605.png">

#### After
<img width="193" alt="Screenshot 2022-10-03 at 18 22 36" src="https://user-images.githubusercontent.com/18654425/193630329-cc6d2799-bd91-4455-af86-909eb39fd30c.png">
<img width="958" alt="Screenshot 2022-10-03 at 18 23 52" src="https://user-images.githubusercontent.com/18654425/193630341-a171d2ae-6381-4a53-87b6-fa796efb5f56.png">
