### PR TITLE
feat: add type="button" to file selector internal button

### DIFF
--- a/src/components/FileSelector/FileSelector.tsx
+++ b/src/components/FileSelector/FileSelector.tsx
@@ -205,6 +205,7 @@ const FileSelector = ({
           <ExtendableButton
             iconName={SSCIconNames.upload}
             isDisabled={isDisabled}
+            type="button"
             variant={ButtonVariants.outline}
           >
             {buttonLabel}


### PR DESCRIPTION
Added type="button" to internal file selector button. This avoids accidental submits if the component is inside  form(type="submit" is used implicitly)