### PR TITLE
feat(logging): implement DS logger

### DIFF
--- a/src/components/FileSelector/FileSelector.tsx
+++ b/src/components/FileSelector/FileSelector.tsx
@@ -16,6 +16,7 @@ import { TextSizes, TextVariants } from '../typographyLegacy/Text/Text.enums';
 import { FileSelectorProps } from './FileSelector.types';
 import { FileSelectorSizes } from './FileSelector.enums';
 import { CLX_COMPONENT } from '../../theme/constants';
+import { useLogger } from '../../hooks/useLogger';
 
 const ExtendableButton = styled(Button)``;
 const FileSelectorWrapper = styled(Padbox)`
@@ -96,6 +97,7 @@ const FileSelector = ({
   className,
   ...props
 }: FileSelectorProps) => {
+  const { error } = useLogger('FileSelector');
   const { getRootProps, getInputProps, isDragActive, isFocused } = useDropzone({
     disabled: isDisabled,
     noClick: isClickDisabled,
@@ -125,11 +127,9 @@ const FileSelector = ({
   const passedProps = omit(['width', 'height'], props);
 
   if (isClickDisabled && isDragDisabled) {
-    if (process.env.NODE_ENV !== 'production') {
-      throw new Error(
-        '[design-system/FileSelector] Either one of or both "isClickDisabled" and "isDragDisabled" properties must be set to "false".',
-      );
-    }
+    error(
+      'Either one of or both "isClickDisabled" and "isDragDisabled" properties must be set to "false".',
+    );
     return null;
   }
 

--- a/src/components/Filters/hooks/useFilterRow.test.ts
+++ b/src/components/Filters/hooks/useFilterRow.test.ts
@@ -25,7 +25,9 @@ describe('useFilterRow', () => {
       useFilterRow(mockTestFields, 'option x', 'xxx'),
     );
     expect(result.error).toEqual(
-      Error('Field value "option x" was not found in the fields array'),
+      Error(
+        '[design-system/useFilterRow] Field value "option x" was not found in the fields array',
+      ),
     );
   });
   it('should throw error when condition is not found', () => {
@@ -35,7 +37,7 @@ describe('useFilterRow', () => {
 
     expect(result.error).toEqual(
       Error(
-        'For field value "option a" was not found condition matching condition value "xxx"',
+        '[design-system/useFilterRow] For field value "option a" was not found condition matching condition value "xxx"',
       ),
     );
   });
@@ -49,7 +51,9 @@ describe('useFilterRow', () => {
     );
 
     expect(result.error).toEqual(
-      Error('Field item does not contain any conditions'),
+      Error(
+        '[design-system/useFilterRow] Field item does not contain any conditions',
+      ),
     );
   });
 });

--- a/src/components/Filters/hooks/useFilterRow.ts
+++ b/src/components/Filters/hooks/useFilterRow.ts
@@ -4,6 +4,7 @@ import { isUndefined } from 'ramda-adjunct';
 import { Condition, Field } from '../Filters.types';
 import { PickOption, UseFilterRowType } from './useFilterRow.types';
 import { Option } from '../components/Select/Select.types';
+import { useLogger } from '../../../hooks/useLogger';
 
 export const normalizeOptions: <O extends Option>(options: O) => PickOption<O> =
   pick(['value', 'label']);
@@ -13,14 +14,13 @@ export const useFilterRow = (
   fieldValue: string,
   conditionValue: string,
 ): UseFilterRowType => {
+  const { error } = useLogger('useFilterRow');
   const field = find(propEq('value', fieldValue), fields);
   if (isUndefined(field))
-    throw new Error(
-      `Field value "${fieldValue}" was not found in the fields array`,
-    );
+    error(`Field value "${fieldValue}" was not found in the fields array`);
 
   if (isUndefined(field.conditions))
-    throw new Error(`Field item does not contain any conditions`);
+    error(`Field item does not contain any conditions`);
   const conditions = pipe(prop('conditions'), map(normalizeOptions))(field);
 
   const condition = pipe(
@@ -28,7 +28,7 @@ export const useFilterRow = (
     find(propEq('value', conditionValue)),
   )(field);
   if (isUndefined(condition))
-    throw new Error(
+    error(
       `For field value "${fieldValue}" was not found condition matching condition value "${conditionValue}"`,
     );
 

--- a/src/components/FullscreenModal/FullscreenModal.tsx
+++ b/src/components/FullscreenModal/FullscreenModal.tsx
@@ -10,6 +10,7 @@ import { FullscreenModalLayouts } from './FullscreenModal.enums';
 import { ColumnConfigMap, FullscreenModalProps } from './FullscreenModal.types';
 import { Col, Container, Row } from '../layout';
 import { useModal } from './hooks/useModal';
+import { useLogger } from '../../hooks/useLogger';
 
 const BaseModal = styled.div`
   width: 100%;
@@ -62,6 +63,7 @@ const FullscreenModalContent = forwardRef(
     }: FullscreenModalProps,
     ref: React.MutableRefObject<HTMLDivElement>,
   ): React.ReactElement => {
+    const { error } = useLogger('FullscreenModal');
     const closeOnEsc = useCallback(
       (e: KeyboardEvent) => {
         if (e.key === 'Escape' || e.key === 'Esc') {
@@ -89,11 +91,12 @@ const FullscreenModalContent = forwardRef(
     const totalContentWidth = contentCols + sidebarCols;
 
     if (hasLayoutSidebar && isUndefined(sidebar)) {
-      throw new Error(
+      error(
         `You chose to use modal layout with sidebar (current: ${layout}) but you didn't provide sidebar content.
 You should either provide content in "sidebar" property or switch layout to "${FullscreenModalLayouts.single6}" or "${FullscreenModalLayouts.single8}"
 `,
       );
+      return null;
     }
 
     return (

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 
+import { useLogger } from '../../hooks/useLogger';
 import { Inline } from '../layout';
 import { InlineProps } from '../layout/Inline/Inline';
 
 const Nav: React.FC<InlineProps> = (props) => {
-  if (process.env.NODE_ENV !== 'production') {
-    console.warn(`<Nav> and <NavItem> components are deprecated and will be removed soon.
+  const { warn } = useLogger('Nav');
+  warn(`<Nav> and <NavItem> components are deprecated and will be removed soon.
 
 Instead please use <Tabs> component (variant: \`text\`, size: \`large\`).
 
 https://securityscorecard.github.io/design-system/alpha/?path=/docs/components-tabs--playground#text-tabs
 `);
-  }
+
   return <Inline as="nav" {...props} />;
 };
 

--- a/src/components/_internal/BaseButton/BaseButton.tsx
+++ b/src/components/_internal/BaseButton/BaseButton.tsx
@@ -28,6 +28,7 @@ import {
 } from './BaseButton.enums';
 import { BaseButtonProps } from './BaseButton.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
+import { useLogger } from '../../../hooks/useLogger';
 
 const BaseStyledIcon = styled(Icon)`
   font-size: ${getToken('font-action-size')};
@@ -55,12 +56,13 @@ const BaseButton: React.FC<
 }) => {
   let RouterLink = null;
   const theme = useTheme();
+  const { warn } = useLogger('Button');
   if (isNull(as) && isNotNull(to)) {
     RouterLink = requireRouterLink();
   }
 
-  if (process.env.NODE_ENV !== 'production' && isDisabled && href) {
-    console.warn(
+  if (isDisabled && href) {
+    warn(
       '"isDisabled" prop in <Button> component will be ignored if the "href" prop is defined',
     );
   }

--- a/src/components/_internal/BaseTable/renderers/LinkRenderer.tsx
+++ b/src/components/_internal/BaseTable/renderers/LinkRenderer.tsx
@@ -3,6 +3,7 @@ import cls from 'classnames';
 import { isNotUndefined, isUndefined, noop } from 'ramda-adjunct';
 
 import { LinkRendererProps } from './renderers.types';
+import { useLogger } from '../../../../hooks/useLogger';
 
 function LinkRenderer<D extends Record<string, unknown>>({
   value,
@@ -14,10 +15,13 @@ function LinkRenderer<D extends Record<string, unknown>>({
   rowData,
   className,
 }: LinkRendererProps<D>): React.ReactElement {
+  const { error } = useLogger('LinkRenderer');
   const isRelativeLink = isNotUndefined(toComposer);
   if (isRelativeLink && isUndefined(component)) {
-    throw new Error(`You are trying to use 'toComposer' property but you didn't provide 'cellLinkComponent'.
+    error(`You are trying to use 'toComposer' property but you didn't provide 'cellLinkComponent'.
 Add valid component to 'cellLinkComponent', e.g. Link or NavLink from 'react-router'`);
+
+    return null;
   }
 
   const to = isRelativeLink ? toComposer(value, rowData) : undefined;

--- a/src/components/forms/InputGroup/InputGroup.tsx
+++ b/src/components/forms/InputGroup/InputGroup.tsx
@@ -15,6 +15,7 @@ import { InlineProps } from '../../layout/Inline/Inline';
 import { Button } from '../../Button';
 import { SearchBar } from '../SearchBar';
 import { CLX_COMPONENT } from '../../../theme/constants';
+import { useLogger } from '../../../hooks/useLogger';
 
 const InputGroupContainer = styled(Inline)<InputGroupProps>`
   border: ${getFormStyle('borderWidth')} solid ${getFormStyle('borderColor')};
@@ -63,6 +64,7 @@ const InputGroup: React.FC<InputGroupProps & InlineProps> = ({
   className,
   ...inlineProps
 }) => {
+  const { error } = useLogger('InputGroup');
   const ALLOWED_CHILDREN = [
     Select,
     Input,
@@ -74,7 +76,7 @@ const InputGroup: React.FC<InputGroupProps & InlineProps> = ({
   ];
   React.Children.forEach(children, (child) => {
     if (!ALLOWED_CHILDREN.includes(prop('type', child))) {
-      throw new Error(
+      error(
         'Only Select, Input, InputGroup, Icon, Button, SearchBar and Password are valid childs of InputGroup',
       );
     }
@@ -96,6 +98,9 @@ const InputGroup: React.FC<InputGroupProps & InlineProps> = ({
   );
 };
 
-InputGroup.propTypes = { className: PropTypes.string };
+InputGroup.propTypes = {
+  hasDivider: PropTypes.bool,
+  className: PropTypes.string,
+};
 
 export default InputGroup;

--- a/src/components/layout/Grid/Grid.tsx
+++ b/src/components/layout/Grid/Grid.tsx
@@ -10,6 +10,7 @@ import { SpaceSizes } from '../../../theme/space.enums';
 import { SpaceSize } from '../../../theme/space.types';
 import { AlignItemsPropType } from '../../../types/flex.types';
 import { CLX_LAYOUT } from '../../../theme/constants';
+import { useLogger } from '../../../hooks/useLogger';
 
 interface GridWrapperProps {
   $overflow: 'hidden' | 'visible';
@@ -79,10 +80,10 @@ const Grid: React.FC<GridProps> = ({
   wrapperOverflow = 'hidden',
   ...props
 }) => {
+  const { error } = useLogger('Grid');
   if (cols === 1) {
-    throw new Error(
-      '[design-system/Grid] Minimal number of columns is 2. Use Stack instead of Grid[cols=1]',
-    );
+    error('Minimal number of columns is 2. Use Stack instead of Grid[cols=1]');
+    return null;
   }
   return (
     <GridWrapper

--- a/src/hooks/useLogger.test.tsx
+++ b/src/hooks/useLogger.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { noop } from 'ramda-adjunct';
+
+import { DSProvider } from '../theme/DSProvider';
+import { useLogger } from './useLogger';
+
+const log = jest.spyOn(console, 'log').mockImplementation(noop);
+const warn = jest.spyOn(console, 'warn').mockImplementation(noop);
+const error = jest.spyOn(console, 'error').mockImplementation(noop);
+const namespace = 'test namespace';
+const message = 'test message';
+
+describe('useLogger', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  describe('log', () => {
+    it('should not call console.log when debug mode is disabled', () => {
+      const wrapper = ({ children }) => (
+        <DSProvider config={{ debugMode: false }}>{children}</DSProvider>
+      );
+      const { result } = renderHook(() => useLogger('useLoggerTest'), {
+        wrapper,
+      });
+
+      result.current.log('log message');
+
+      expect(log).not.toBeCalled();
+    });
+    it('should call console.log when debug mode is enabled', () => {
+      const wrapper = ({ children }) => (
+        <DSProvider config={{ debugMode: true }}>{children}</DSProvider>
+      );
+      const { result } = renderHook(() => useLogger('useLoggerTest'), {
+        wrapper,
+      });
+
+      result.current.log('log message');
+
+      expect(log).toBeCalled();
+    });
+    it('should call console.log with correct namespace and message', () => {
+      const wrapper = ({ children }) => (
+        <DSProvider config={{ debugMode: true }}>{children}</DSProvider>
+      );
+      const { result } = renderHook(() => useLogger(namespace), {
+        wrapper,
+      });
+
+      result.current.log(message);
+
+      expect(log).toBeCalledWith(
+        `%c[design-system/${namespace}]  `,
+        'color: darkturquoise;font-weight: bold',
+        message,
+      );
+    });
+  });
+
+  describe('warn', () => {
+    it('should not call console.warn when NODE_ENV=production', () => {
+      const OLD_NODE_ENV = process.env.NODE_ENV;
+      jest.resetModules();
+      process.env.NODE_ENV = 'production';
+      const wrapper = ({ children }) => (
+        <DSProvider config={{ debugMode: false }}>{children}</DSProvider>
+      );
+      const { result } = renderHook(() => useLogger('useLoggerTest'), {
+        wrapper,
+      });
+
+      result.current.warn('log message');
+
+      expect(warn).not.toBeCalled();
+      process.env.NODE_ENV = OLD_NODE_ENV;
+    });
+
+    describe('given NODE_ENV is not production', () => {
+      it('should call console.warn', () => {
+        const wrapper = ({ children }) => (
+          <DSProvider config={{ debugMode: false }}>{children}</DSProvider>
+        );
+        const { result } = renderHook(() => useLogger('useLoggerTest'), {
+          wrapper,
+        });
+
+        expect(() => result.current.warn('log message')).not.toThrowError();
+
+        expect(warn).toBeCalled();
+      });
+      it('should call console.warn with correct namespace and message', () => {
+        const wrapper = ({ children }) => (
+          <DSProvider config={{ debugMode: true }}>{children}</DSProvider>
+        );
+        const { result } = renderHook(() => useLogger(namespace), {
+          wrapper,
+        });
+
+        result.current.warn(message);
+
+        expect(warn).toBeCalledWith(
+          `%c[design-system/${namespace}]  `,
+          'color: darkorange;font-weight: bold',
+          message,
+        );
+      });
+    });
+  });
+
+  describe('error', () => {
+    describe('given NODE_ENV=production', () => {
+      const OLD_NODE_ENV = process.env.NODE_ENV;
+      beforeAll(() => {
+        jest.resetModules();
+        process.env.NODE_ENV = 'production';
+      });
+      afterAll(() => {
+        process.env.NODE_ENV = OLD_NODE_ENV;
+      });
+      it('should call console.error', () => {
+        const wrapper = ({ children }) => (
+          <DSProvider config={{ debugMode: false }}>{children}</DSProvider>
+        );
+        const { result } = renderHook(() => useLogger('useLoggerTest'), {
+          wrapper,
+        });
+
+        expect(() => result.current.error('log message')).not.toThrowError();
+
+        expect(error).toBeCalled();
+      });
+      it('should call console.error with correct namespace and message', () => {
+        const wrapper = ({ children }) => (
+          <DSProvider config={{ debugMode: true }}>{children}</DSProvider>
+        );
+        const { result } = renderHook(() => useLogger(namespace), {
+          wrapper,
+        });
+
+        result.current.error(message);
+
+        expect(error).toBeCalledWith(
+          `%c[design-system/${namespace}]  `,
+          'color: crimson;font-weight: bold',
+          message,
+        );
+      });
+    });
+    describe('given NODE_ENV is not production', () => {
+      it('should throw error', () => {
+        const wrapper = ({ children }) => (
+          <DSProvider config={{ debugMode: false }}>{children}</DSProvider>
+        );
+        const { result } = renderHook(() => useLogger('useLoggerTest'), {
+          wrapper,
+        });
+
+        expect(() => result.current.error('log message')).toThrowError();
+        expect(error).not.toBeCalled();
+      });
+      it('should call console.error with correct namespace and message', () => {
+        const wrapper = ({ children }) => (
+          <DSProvider config={{ debugMode: false }}>{children}</DSProvider>
+        );
+        const { result } = renderHook(() => useLogger(namespace), {
+          wrapper,
+        });
+
+        expect(() => result.current.error(message)).toThrowError(
+          `[design-system/${namespace}] ${message}`,
+        );
+      });
+    });
+  });
+});

--- a/src/hooks/useLogger.ts
+++ b/src/hooks/useLogger.ts
@@ -1,0 +1,41 @@
+import { useContext } from 'react';
+
+import { DSContext } from '../theme/DSProvider/DSProvider';
+
+const styles = ['font-weight: bold'];
+export const logStyles = ['color: darkturquoise', ...styles].join(';');
+export const warnStyles = ['color: darkorange', ...styles].join(';');
+export const errorStyles = ['color: crimson', ...styles].join(';');
+
+export const logError = (namespace, message) => {
+  if (process.env.NODE_ENV !== 'production') {
+    throw new Error(`[design-system/${namespace}] ${message}`);
+  } else {
+    // eslint-disable-next-line no-console
+    console.error(`%c[design-system/${namespace}]  `, errorStyles, message);
+  }
+};
+// eslint-disable-next-line import/prefer-default-export
+export const useLogger = (namespace: string) => {
+  const { debugMode } = useContext(DSContext);
+
+  return {
+    log: (message: string) => {
+      if (!debugMode) {
+        return;
+      }
+      // eslint-disable-next-line no-console
+      console.log(`%c[design-system/${namespace}]  `, logStyles, message);
+    },
+    warn: (message: string) => {
+      if (process.env.NODE_ENV === 'production') {
+        return;
+      }
+      // eslint-disable-next-line no-console
+      console.warn(`%c[design-system/${namespace}]  `, warnStyles, message);
+    },
+    error: (message: string) => {
+      logError(namespace, message);
+    },
+  };
+};

--- a/src/hooks/useWhyDidYouUpdate.ts
+++ b/src/hooks/useWhyDidYouUpdate.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react';
 
+import { logStyles } from './useLogger';
+
 export const useWhyDidYouUpdate = (
   name: string,
   props: Record<string, unknown>,
@@ -29,7 +31,12 @@ export const useWhyDidYouUpdate = (
       // If changesObj not empty then output to console
       if (Object.keys(changesObj).length) {
         // eslint-disable-next-line no-console
-        console.log('[why-did-you-update]', name, changesObj);
+        console.log(
+          '%c[design-system/why-did-you-update]',
+          logStyles,
+          name,
+          changesObj,
+        );
       }
     }
 

--- a/src/managers/BannersManager/BannersProvider.test.tsx
+++ b/src/managers/BannersManager/BannersProvider.test.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 
-import { BannersProvider, errorMessage, useBanners } from './BannersProvider';
+import { BannersProvider, useBanners } from './BannersProvider';
 
 describe('BannersManager/useBanners', () => {
   it('should throw when used outside of BannersProvider', () => {
     const { result } = renderHook(() => useBanners());
 
-    expect(result.error).toStrictEqual(Error(errorMessage));
+    expect(result.error).toStrictEqual(
+      Error(
+        '[design-system/banner-manager] "useBanners" must be inside a "BannersProvider" with a value',
+      ),
+    );
   });
 
   it('should return context value', () => {

--- a/src/managers/BannersManager/BannersProvider.tsx
+++ b/src/managers/BannersManager/BannersProvider.tsx
@@ -7,9 +7,10 @@ import { createCtx } from '../common/createCtx';
 import { ACTIONS } from './enums';
 import { useManagerEvents } from '../common/useManagerEvents';
 
-export const errorMessage =
-  '[banner-manager] "useBanners" must be inside a "BannersProvider" with a value';
-const BannersContext = createCtx<BannersContextProps>(errorMessage);
+const BannersContext = createCtx<BannersContextProps>(
+  'banner-manager',
+  '"useBanners" must be inside a "BannersProvider" with a value',
+);
 
 export const useBanners = BannersContext.useContext;
 export const BannersProvider = ({

--- a/src/managers/common/createCtx.ts
+++ b/src/managers/common/createCtx.ts
@@ -1,10 +1,13 @@
 import { createContext, useContext } from 'react';
 
-export function createCtx<P>(errorMessage: string) {
+import { useLogger } from '../../hooks/useLogger';
+
+export function createCtx<P>(namespace: string, errorMessage: string) {
   const ctx = createContext<P | undefined>(undefined);
   function useCtx() {
+    const { error } = useLogger(namespace);
     const c = useContext(ctx);
-    if (!c) throw new Error(errorMessage);
+    if (!c) error(errorMessage);
     return c;
   }
   return {

--- a/src/theme/DSProvider/DSProvider.tsx
+++ b/src/theme/DSProvider/DSProvider.tsx
@@ -10,6 +10,7 @@ import { DSContextValue, DSProviderProps } from './DSProvider.types';
 export const defaultDSContext = {
   portalsContainerId: 'portals',
   hasIncludedGlobalStyles: true,
+  debugMode: false,
 };
 export const DSContext = React.createContext<DSContextValue>(defaultDSContext);
 

--- a/src/theme/DSProvider/DSProvider.types.ts
+++ b/src/theme/DSProvider/DSProvider.types.ts
@@ -3,6 +3,7 @@ import { DefaultTheme } from 'styled-components';
 export interface DSContextValue {
   portalsContainerId: string;
   hasIncludedGlobalStyles: boolean;
+  debugMode: boolean;
 }
 export interface DSProviderProps {
   /**

--- a/src/utils/require-router-link.ts
+++ b/src/utils/require-router-link.ts
@@ -1,10 +1,13 @@
+import { logError } from '../hooks/useLogger';
+
 export const requireRouterLink = (): React.ReactNode | null => {
   try {
     // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
     return require('react-router-dom').Link;
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.error(
+    logError(
+      'router-link',
       `You're trying to use Link component without 'react-router-dom' installed as dependency
 of your project. To resolve this issue you can:
 - install 'react-router-dom' as project dependency


### PR DESCRIPTION
This PR adds `useLogger` hook that return `log`, `warn` and `error` methods. Those methods can be used for guarded logging inside DS.

- `log` method is calling `console.log` when debug mode is enabled in DSProvider config
- `warn` method is calling `console.warn` when the DS is not running in production environment
- `error` method throws an error when DS is not running in production environment and calls `console.error` in production

Closes UXD-970