### PR TITLE
build(docs): run docs deploy on release

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   unit-tests:
+    name: '🛟 Run unit tests'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,6 +47,7 @@ jobs:
         run: yarn test
 
   types:
+    name: '🪪 Check typings'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -81,6 +83,7 @@ jobs:
         run: yarn types
 
   visual-tests:
+    name: '🖼 Run visual tests'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -138,6 +141,7 @@ jobs:
           path: visual-test-reports.tar
 
   lint:
+    name: '🧹 Run lint'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -173,6 +177,7 @@ jobs:
         run: yarn lint
 
   lint-css:
+    name: '🎨 Lint CSS'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -208,6 +213,7 @@ jobs:
         run: yarn lint:css
 
   betterer:
+    name: "🚧 Check Betterer rules"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -243,6 +249,7 @@ jobs:
         run: yarn betterer:ci
 
   build:
+    name: '🧰 Build package'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -293,6 +300,7 @@ jobs:
           path: stats
 
   build-and-publish:
+    name: '🚀 Publish new version'
     if: "github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/alpha') && !contains(github.event.head_commit.message, 'chore(release):')"
     needs: [unit-tests, visual-tests, types, lint, lint-css, betterer, build]
     runs-on: ubuntu-latest
@@ -347,78 +355,136 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org:8443/
 
-  # build-docs:
-  #   needs: build-and-publish
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #         ref: alpha
+  get-next-version:
+    name: '📟 Get next released version'
+    if: "github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/alpha') && !contains(github.event.head_commit.message, 'chore(release):')"
+    needs: [unit-tests, visual-tests, types, lint, lint-css, betterer, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - name: Setup Node.js
-  #       uses: actions/setup-node@v3
-  #       with:
-  #         node-version: 16
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
-  #     - name: Setup Pages
-  #       uses: actions/configure-pages@v2
+      - name: Cache yarn pnp files
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            .yarn/cache
+            .yarn/unplugged
+            .yarn/install-state.gz
+            .pnp.cjs
+            .pnp.loader.mjs
+          key: ${{ runner.os }}-node-16-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-16-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
-  #     - name: Install
-  #       run: yarn install --frozen-lockfile
+      - name: Install Packages
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
 
-  #     - name: Get version
-  #       id: get_version
-  #       run: |
-  #         echo  "packageVersion=$(git describe --tags)" >> $GITHUB_ENV
+      - name: Run Semantic Release
+        run: yarn semantic-release --dry-run
+        id: get-next-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org:8443/
 
-  #     - name: Cache storybook build
-  #       id: storybook-build-cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: docs-build
-  #         key: docs-${{ hashFiles('**/yarn.lock', '**/package.json', 'src/**', '!.storybook/image-snapshots/**' ,'.storybook/**') }}
-  #         restore-keys: |
-  #           docs-
+    outputs:
+      new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
+      new-release-version: ${{ steps.get-next-version.outputs.new-release-version }}
 
-  #     - name: Build Storybook
-  #       if: steps.storybook-build-cache.outputs.cache-hit != 'true'
-  #       run: yarn build-storybook -o ./docs-build/${{ env.packageVersion }}
+  build-docs:
+    name: '📒 Build documentation'
+    needs: [get-next-version, build-and-publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: alpha
 
-  #     - name: Generate redirect index
-  #       env:
-  #         VERSION: ${{ env.packageVersion }}
-  #       run: |
-  #         yarn node ./scripts/generate-index.js
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
-  #     - name: Upload Storybook artifact
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: storybook
-  #         path: ./docs-build
-  #         retention-days: 1
+      - name: Cache yarn pnp files
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            .yarn/cache
+            .yarn/unplugged
+            .yarn/install-state.gz
+            .pnp.cjs
+            .pnp.loader.mjs
+          key: ${{ runner.os }}-node-16-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-16-${{ env.cache-name }}-
+            ${{ runner.os }}-node-${{ env.cache-name }}-
+            ${{ runner.os }}-node-
+            ${{ runner.os }}-
 
+      - name: Install Packages
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --immutable
 
-  # deploy-docs:
-  #   needs: build-docs
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #       with:
-  #         ref: gh-pages
+      - name: Cache storybook build
+        id: storybook-build-cache
+        uses: actions/cache@v3
+        with:
+          path: docs-build
+          key: docs-${{ hashFiles('**/yarn.lock', '**/package.json', 'src/**', '!.storybook/image-snapshots/**' ,'.storybook/**') }}
+          restore-keys: |
+            docs-
 
-  #     - name: Download Storybook artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: storybook
+      - name: Build Storybook
+        if: steps.storybook-build-cache.outputs.cache-hit != 'true'
+        run: yarn build-storybook -o ./docs-build/${{ needs.get-next-version.outputs.new-release-version }}
 
-  #     - name: Commit storybook
-  #       run: |
-  #         git config --global user.name "Continuous Integration"
-  #         git config --global user.email "username@users.noreply.github.com"
-  #         git add -A
-  #         git commit -m "Publish docs for ${{ env.packageVersion }}"
-  #         git push
+      - name: Generate redirect index
+        env:
+          VERSION: ${{ needs.get-next-version.outputs.new-release-version }}
+        run: |
+          yarn node ./scripts/generate-index.js
 
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: storybook
+          path: ./docs-build
+          retention-days: 1
+
+  deploy-docs:
+    name: '📤 Deploy documentation'
+    needs: [get-next-version, build-docs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: storybook
+
+      - name: Commit storybook
+        run: |
+          git config --global user.name "Continuous Integration"
+          git config --global user.email "username@users.noreply.github.com"
+          git add -A
+          git commit -m "Publish docs for ${{ needs.get-next-version.outputs.new-release-version }}"
+          git push

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -22,7 +22,8 @@
         "assets": ["package.json", "yarn.lock", "CHANGELOG.md"],
         "message": "chore(release): bump version to ${nextRelease.version}\n\n${nextRelease.notes}"
       }
-    ]
+    ],
+    "semantic-release-export-data"
   ],
   "preset": "angular"
 }

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "rollup-plugin-typescript2": "^0.31.2",
     "rollup-plugin-visualizer": "^5.6.0",
     "semantic-release": "^19.0.2",
+    "semantic-release-export-data": "^1.0.1",
     "storybook-addon-designs": "^6.2.1",
     "storybook-addon-outline": "^1.4.2",
     "storycap": "3.0.4",

--- a/scripts/generate-index.js
+++ b/scripts/generate-index.js
@@ -3,23 +3,28 @@ const fs = require('fs');
 const path = require('path');
 /* eslint-enable @typescript-eslint/no-var-requires */
 
-const docsRootPath = path.resolve(__dirname, '../docs-build/index.html');
+const docsRootPath = path.resolve(__dirname, '../docs-build');
+const alphaDocsRootPath = path.resolve(__dirname, '../docs-build/alpha');
 const version = process.env.VERSION;
 const url = `https://securityscorecard.github.io/design-system/${version}`;
 const content = `<!DOCTYPE HTML>
 <html lang="en-US">
-    <head>
-        <meta charset="UTF-8">
-        <meta http-equiv="refresh" content="1; url=${url}">
-        <script type="text/javascript">
-            window.location.href = "${url}"
-        </script>
-        <title>Page Redirection</title>
-    </head>
-    <body>
-        If you are not redirected automatically, use this <a href='${url}'>link</a>.
-    </body>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="1; url=${url}">
+    <script type="text/javascript">
+      window.location.href = "${url}"
+    </script>
+    <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, use this <a href='${url}'>link</a>.
+  </body>
 </html>
 `;
 
-fs.writeFileSync(docsRootPath, content);
+fs.mkdirSync(alphaDocsRootPath, { recursive: true }, (err) => {
+  if (err) throw err;
+});
+fs.writeFileSync(`${docsRootPath}/index.html`, content);
+fs.writeFileSync(`${alphaDocsRootPath}/index.html`, content);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,25 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@actions/core@npm:^1.10.0":
+  version: 1.10.0
+  resolution: "@actions/core@npm:1.10.0"
+  dependencies:
+    "@actions/http-client": ^2.0.1
+    uuid: ^8.3.2
+  checksum: 0a75621e007ab20d887434cdd165f0b9036f14c22252a2faed33543d8b9d04ec95d823e69ca636a25245574e4585d73e1e9e47a845339553c664f9f2c9614669
+  languageName: node
+  linkType: hard
+
+"@actions/http-client@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@actions/http-client@npm:2.0.1"
+  dependencies:
+    tunnel: ^0.0.6
+  checksum: 799ec3df91e28a9da91ce6592e94f8b8923ccf6cc21a2f72c7429be5af5273f1625335411adc2a1bb222d56c852d5767214dfa6fa32a6da7e81dba8290e08f17
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.1.0":
   version: 2.2.0
   resolution: "@ampproject/remapping@npm:2.2.0"
@@ -3489,6 +3508,7 @@ __metadata:
     rollup-plugin-typescript2: ^0.31.2
     rollup-plugin-visualizer: ^5.6.0
     semantic-release: ^19.0.2
+    semantic-release-export-data: ^1.0.1
     storybook-addon-designs: ^6.2.1
     storybook-addon-outline: ^1.4.2
     storycap: 3.0.4
@@ -18771,6 +18791,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semantic-release-export-data@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "semantic-release-export-data@npm:1.0.1"
+  dependencies:
+    "@actions/core": ^1.10.0
+  peerDependencies:
+    semantic-release: ">=18"
+  checksum: f46d4d5ca5dcd1bd8c573e1a5da4525ffdb50dfc9c0eebaa1cb5e187786c01b4372306173230991cd337ac42de4c0f131c0a32bbf2634d16ee65488544dbd7e8
+  languageName: node
+  linkType: hard
+
 "semantic-release@npm:^19.0.2":
   version: 19.0.3
   resolution: "semantic-release@npm:19.0.3"
@@ -20626,6 +20657,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tunnel@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "tunnel@npm:0.0.6"
+  checksum: c362948df9ad34b649b5585e54ce2838fa583aa3037091aaed66793c65b423a264e5229f0d7e9a95513a795ac2bd4cb72cda7e89a74313f182c1e9ae0b0994fa
+  languageName: node
+  linkType: hard
+
 "type-check@npm:^0.4.0, type-check@npm:~0.4.0":
   version: 0.4.0
   resolution: "type-check@npm:0.4.0"
@@ -21238,6 +21276,15 @@ __metadata:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update to the last attempt to auto-release docs with a new package version.
This time I added a dry-run step for semantic release that will tell us two things:
1) Will a new version be released?
2) What version will be released?

With this knowledge, we can limit documentation release for cases when a new package version is released. The following version number will allow us to version the documentation to provide documentation for previous versions of the Design System.