### PR TITLE
feat(Breadcrumbs): change children to list items

### DIFF
--- a/src/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -37,20 +37,23 @@ const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
   to = undefined,
   href = undefined,
   ...props
-}) =>
-  isSelected ? (
-    <Text
-      aria-current="page"
-      size={TextSizes.md}
-      variant={TextEnums.TextVariants.secondary}
-    >
-      {children}
-    </Text>
-  ) : (
-    <BreadcrumbLink href={href} to={to} {...props}>
-      {children}
-    </BreadcrumbLink>
-  );
+}) => (
+  <li>
+    {isSelected ? (
+      <Text
+        aria-current="page"
+        size={TextSizes.md}
+        variant={TextEnums.TextVariants.secondary}
+      >
+        {children}
+      </Text>
+    ) : (
+      <BreadcrumbLink href={href} to={to} {...props}>
+        {children}
+      </BreadcrumbLink>
+    )}
+  </li>
+);
 
 BreadcrumbItem.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -31,6 +31,10 @@ const BreadcrumbLink = styled(Link)`
   }
 `;
 
+const ListItem = styled.li`
+  list-style-type: none;
+`;
+
 const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
   children,
   isSelected = false,
@@ -38,7 +42,7 @@ const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
   href = undefined,
   ...props
 }) => (
-  <li>
+  <ListItem>
     {isSelected ? (
       <Text
         aria-current="page"
@@ -52,7 +56,7 @@ const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
         {children}
       </BreadcrumbLink>
     )}
-  </li>
+  </ListItem>
 );
 
 BreadcrumbItem.propTypes = {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -15,7 +15,7 @@ import { ColorTypes, SpaceSizes } from '../../theme';
 import { Inline } from '../layout';
 import { CLX_COMPONENT } from '../../theme/constants';
 
-const IconWrapper = styled.div`
+const IconWrapper = styled.li`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -39,6 +39,10 @@ const BreadcrumbsWrapper = styled.nav`
   display: flex;
 `;
 
+const InlineOrderedList = styled(Inline)`
+  padding: 0;
+`;
+
 const itemsAfterCollapse = 2;
 const itemsBeforeCollapse = 1;
 const maxItems = 3;
@@ -135,13 +139,18 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
       aria-label="Breadcrumb"
       className={cls(CLX_COMPONENT, className)}
     >
-      <Inline align="center" as="ol" gap={SpaceSizes.xs} justify="center">
+      <InlineOrderedList
+        align="center"
+        as="ol"
+        gap={SpaceSizes.xs}
+        justify="center"
+      >
         {insertSeparators(
           maxItems && allItems.length <= maxItems
             ? allItems
             : renderItemsBeforeAndAfter(allItems, allDropdownActions),
         )}
-      </Inline>
+      </InlineOrderedList>
     </BreadcrumbsWrapper>
   );
 };


### PR DESCRIPTION
implements https://zitenote.atlassian.net/browse/UXD-1012

removed default list styles
<img width="375" alt="Screenshot 2023-01-06 at 12 05 45" src="https://user-images.githubusercontent.com/23432257/211000641-fc8bc5f3-5c41-489f-a087-b85209b17884.png">
