### PR TITLE
feat: add same content height, hide non active steps in wizard

### DIFF
--- a/src/components/Wizard/WizardStep.tsx
+++ b/src/components/Wizard/WizardStep.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import { useRegisterStep } from './hooks/useRegisterStep';
 import { WizardActionPropType, WizardStepProps } from './Wizard.types';
 import { useActiveStep } from './hooks/useActiveStep';
+import { pxToRem } from '../../utils';
+
+const StepContainer = styled.div`
+  height: ${pxToRem(418)};
+`;
 
 const WizardStep: React.FC<WizardStepProps> = ({
   children,
@@ -12,7 +18,7 @@ const WizardStep: React.FC<WizardStepProps> = ({
   const activeStep = useActiveStep();
   const isActiveStep = activeStep?.id === step.id;
   useRegisterStep(step);
-  return isActiveStep ? <div>{children}</div> : null;
+  return isActiveStep ? <StepContainer>{children}</StepContainer> : null;
 };
 
 WizardStep.propTypes = {

--- a/src/components/Wizard/WizardStepper.tsx
+++ b/src/components/Wizard/WizardStepper.tsx
@@ -11,7 +11,7 @@ export const WizardStepper = () => {
   const navigation = useWizardNavigation();
   const activeStepIndex = steps.findIndex((item) => item.id === activeStep.id);
   return steps.length >= 3 ? (
-    <Stepper activeStep={activeStepIndex}>
+    <Stepper activeStep={activeStepIndex} showTextBreakpoint={10000}>
       {steps.map((item) => (
         <Step
           key={item.id}


### PR DESCRIPTION
This PR adjusts the Wizard to have
1. the same height of the content container, because if the step content differs it results in different positioning of the CTAs, by unifying the height we are enabling fast clicking through all the steps without need moving the mouse to find the Skip button. This also creates a constrain for how much content we can fit into the step but so far for all the use cases we had it wasn't a problem
2. enough space for step label, it hides all the step labels in the stepper but the active step 

**Before**
![image](https://user-images.githubusercontent.com/9460898/210562343-3ae714bd-3f56-4ce8-aadf-382e4e3f3ddf.png)

**After**
![image](https://user-images.githubusercontent.com/9460898/210562189-1f563657-5a4e-49f9-9af1-53d2a8eff35b.png)

- 