### PR TITLE
refactor(types): add type imports and remove React import

### DIFF
--- a/.betterer/.betterer.results
+++ b/.betterer/.betterer.results
@@ -5,8 +5,8 @@
 //
 exports[`no more deprecated components`] = {
   value: `{
-    "../src/components/FlexContainer/FlexContainer.stories.tsx:4149088262": [
-      [4, 0, 44, "\'./FlexContainer\' import is restricted from being used by a pattern. FlexContainer is deprecated. Please use Layout primitives instead.", "3021642676"]
+    "../src/components/FlexContainer/FlexContainer.stories.tsx:4113046884": [
+      [3, 0, 44, "\'./FlexContainer\' import is restricted from being used by a pattern. FlexContainer is deprecated. Please use Layout primitives instead.", "3021642676"]
     ],
     "../src/components/FlexContainer/index.ts:2522931416": [
       [0, 0, 59, "\'./FlexContainer\' import is restricted from being used by a pattern. FlexContainer is deprecated. Please use Layout primitives instead.", "3330215570"]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
     '@typescript-eslint/no-useless-constructor': 'error',
     'no-use-before-define': 'off',
     '@typescript-eslint/no-use-before-define': ['error'],
+    '@typescript-eslint/consistent-type-imports': 'error',
     'import/extensions': [
       'error',
       'ignorePackages',
@@ -66,6 +67,7 @@ module.exports = {
       'error',
       {
         groups: [
+          'type',
           ['builtin', 'external'],
           'internal',
           ['parent', 'sibling', 'index'],

--- a/.storybook/blocks/FontPallete.tsx
+++ b/.storybook/blocks/FontPallete.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import type { FC } from 'react';
 import styled from 'styled-components';
 
 import { theme } from '../../src/theme';
@@ -73,7 +73,7 @@ interface FontProps {
   sampleText: string;
 }
 
-export const FontItem: FunctionComponent<FontProps> = ({
+export const FontItem: FC<FontProps> = ({
   title,
   subtitle,
   fontFamily = theme.typography.family.base,
@@ -100,7 +100,7 @@ export const FontItem: FunctionComponent<FontProps> = ({
   );
 };
 
-export const FontPalette: FunctionComponent = ({ children, ...props }) => (
+export const FontPalette: FC = ({ children, ...props }) => (
   <List {...props}>
     <ListHeading>
       <ListName>Name</ListName>

--- a/.storybook/blocks/SpaceScale.tsx
+++ b/.storybook/blocks/SpaceScale.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { endsWith } from 'ramda'
+import { endsWith } from 'ramda';
 
-import { Table, TableBody, TableHead, Token } from "./components"
+import { Table, TableBody, TableHead, Token } from './components';
 
-export const SpaceScale = ({scale}) => {
+export const SpaceScale = ({ scale }) => {
   const sizes = Object.keys(scale);
   return (
     <Table>
@@ -16,21 +15,27 @@ export const SpaceScale = ({scale}) => {
         </tr>
       </TableHead>
       <TableBody>
-      {sizes.map(size => (
-        <tr key={size}>
-          <td><Token>theme.space.{size}</Token></td>
-          <td>{scale[size] / 16}</td>
-          <td>{scale[size]}</td>
-          <td>
-            <div style={{
-              width: `${scale[size]}px`,
-              height: `${scale[size]}px`,
-              backgroundColor: endsWith('Plus', size) ? '#FF79C9' : '#0275D8',
-            }} />
-          </td>
-        </tr>
-      ))}
+        {sizes.map((size) => (
+          <tr key={size}>
+            <td>
+              <Token>theme.space.{size}</Token>
+            </td>
+            <td>{scale[size] / 16}</td>
+            <td>{scale[size]}</td>
+            <td>
+              <div
+                style={{
+                  width: `${scale[size]}px`,
+                  height: `${scale[size]}px`,
+                  backgroundColor: endsWith('Plus', size)
+                    ? '#FF79C9'
+                    : '#0275D8',
+                }}
+              />
+            </td>
+          </tr>
+        ))}
       </TableBody>
     </Table>
-  )
-}
+  );
+};

--- a/.storybook/blocks/StoriesWithDesign.tsx
+++ b/.storybook/blocks/StoriesWithDesign.tsx
@@ -1,4 +1,5 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
+import type { FC } from 'react';
 import {
   DocsContext,
   DocsStory,
@@ -10,23 +11,23 @@ import {
   Canvas,
   Story,
 } from '@storybook/addon-docs';
-import { TabsState } from '@storybook/components'
+import { TabsState } from '@storybook/components';
 import { Design } from 'storybook-addon-designs/blocks';
-import { isNonEmptyString } from 'ramda-adjunct'
-import styled from 'styled-components';
-
-const ImplementationBlock = styled.div`
-  padding-top: 25px;
-`;
+import { isNonEmptyString } from 'ramda-adjunct';
 
 interface StoriesProps {
   title?: JSX.Element | string;
   includePrimary?: boolean;
 }
 
-export const StoriesWithDesign: React.FC<StoriesProps> = ({ title, includePrimary = false }) => {
+export const StoriesWithDesign: FC<StoriesProps> = ({
+  title,
+  includePrimary = false,
+}) => {
   const context = useContext(DocsContext);
-  const componentStories = context.componentStories().filter((s: any) => !(s.parameters?.docs?.disable));;
+  const componentStories = context
+    .componentStories()
+    .filter((s: any) => !s.parameters?.docs?.disable);
 
   let stories: DocsStoryProps[] = componentStories;
   if (!includePrimary) stories = stories.slice(1);
@@ -38,8 +39,13 @@ export const StoriesWithDesign: React.FC<StoriesProps> = ({ title, includePrimar
     <>
       <Heading>{title}</Heading>
       {stories.map((story) => {
-        if (story)  {
-          const { id, name, withToolbar, parameters: { docs, design } } = story;
+        if (story) {
+          const {
+            id,
+            name,
+            withToolbar,
+            parameters: { docs, design },
+          } = story;
           const description = docs.description?.story;
 
           return isNonEmptyString(design?.url) ? (
@@ -48,16 +54,18 @@ export const StoriesWithDesign: React.FC<StoriesProps> = ({ title, includePrimar
               {description && <Description markdown={description} />}
               <TabsState initial="implementation">
                 <div id="implementation" title="Implementation">
-                    <Canvas withToolbar={withToolbar}>
-                      <Story id={id} />
-                    </Canvas>
+                  <Canvas withToolbar={withToolbar}>
+                    <Story id={id} />
+                  </Canvas>
                 </div>
                 <div id="design" title="Design">
                   <Design storyId={id} />
                 </div>
               </TabsState>
             </Anchor>
-          ) : <DocsStory key={story.id} {...story} expanded />;
+          ) : (
+            <DocsStory key={story.id} {...story} expanded />
+          );
         }
 
         return null;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { withScreenshot } from 'storycap';
 import { withDesign } from 'storybook-addon-designs';
 import {

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,12 +1,13 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { AccordionProps } from './Accordion.types';
+
+import { useState } from 'react';
 
 import { Inline, Stack } from '../layout';
 import { HexGrade } from '../HexGrade';
 import { Paragraph, Text } from '../typographyLegacy';
 import { Button } from '../Button';
 import Accordion from './Accordion';
-import { AccordionProps } from './Accordion.types';
 
 export default {
   title: 'components/Accordion',

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,15 +1,18 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import type {
+  AccordionItem,
+  AccordionItemId,
+  AccordionProps,
+} from './Accordion.types';
+
+import { forwardRef, useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { equals, filter, includes, pipe, pluck, propEq, reject } from 'ramda';
 import cls from 'classnames';
 
 import { Stack } from '../layout';
 import {
-  AccordionItem,
-  AccordionItemId,
   AccordionItemIdPropType,
   AccordionItemPropType,
-  AccordionProps,
 } from './Accordion.types';
 import AccordionCollapsible from './AccordionCollapsible';
 import { CLX_COMPONENT } from '../../theme/constants';
@@ -33,7 +36,7 @@ function filterState(
   return [...state, item];
 }
 
-const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
+const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
   (
     {
       isCollapsedOnOpen = true,

--- a/src/components/Accordion/Accordion.types.ts
+++ b/src/components/Accordion/Accordion.types.ts
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+
 import PropTypes from 'prop-types';
 
 export type AccordionItemId = string | number;

--- a/src/components/Accordion/AccordionCollapsible.tsx
+++ b/src/components/Accordion/AccordionCollapsible.tsx
@@ -1,4 +1,9 @@
-import React from 'react';
+import type { FC, KeyboardEvent } from 'react';
+import type {
+  AccordionCollapsibleProps,
+  AccordionItemId,
+} from './Accordion.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { transparentize } from 'polished';
@@ -8,11 +13,7 @@ import { getColor, getSpace, pxToRem } from '../../utils';
 import { Icon } from '../Icon';
 import { Text } from '../typographyLegacy';
 import { TextSizes } from '../typographyLegacy/Text/Text.enums';
-import {
-  AccordionCollapsibleProps,
-  AccordionItemId,
-  AccordionItemIdPropType,
-} from './Accordion.types';
+import { AccordionItemIdPropType } from './Accordion.types';
 import { Inline, Padbox } from '../layout';
 import { SpaceSizes } from '../../theme';
 import { PaddingTypes } from '../layout/Padbox/Padbox.enums';
@@ -58,7 +59,7 @@ const StyledIcon = styled(Icon)`
   height: 1em;
 `;
 
-const AccordionCollapsible: React.FC<AccordionCollapsibleProps> = ({
+const AccordionCollapsible: FC<AccordionCollapsibleProps> = ({
   children,
   className,
   handleHeaderClick,
@@ -68,7 +69,7 @@ const AccordionCollapsible: React.FC<AccordionCollapsibleProps> = ({
   title,
 }) => {
   const handleKeyDown = (
-    e: React.KeyboardEvent<HTMLDivElement>,
+    e: KeyboardEvent<HTMLDivElement>,
     itemId?: AccordionItemId,
   ) => {
     if (e.key === 'Enter' || e.key === ' ') {

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { BadgeProps } from './Badge.types';
 
 import Badge from './Badge';
-import { BadgeProps } from './Badge.types';
 import { BadgeVariants } from './Badge.enums';
 import { generateControl } from '../../utils/tests/storybook';
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { BadgeElementProps, BadgeProps } from './Badge.types';
+import type { SSCIcons, Types } from '../Icon/Icon.types';
+
 import PropTypes from 'prop-types';
 import { defaultWhen } from 'ramda-adjunct';
 import { lte, pipe } from 'ramda';
 import styled, { css } from 'styled-components';
 
-import type { BadgeElementProps, BadgeProps } from './Badge.types';
 import { BadgeVariants } from './Badge.enums';
 import {
   getColor,
@@ -15,7 +17,6 @@ import {
 } from '../../utils';
 import { CLX_COMPONENT } from '../../theme/constants';
 import { SpaceSizes } from '../../theme';
-import { SSCIcons, Types } from '../Icon/Icon.types';
 import { IconTypes, SSCIconNames } from '../../theme/icons/icons.enums';
 import { Icon } from '../Icon';
 import { Inline, Padbox } from '../layout';
@@ -63,7 +64,7 @@ const BadgeElement = styled(Padbox)<BadgeElementProps>`
 
 const normalizeCount = pipe(defaultWhen(lte(100), '99+'));
 
-const Badge: React.FC<BadgeProps> = ({
+const Badge: FC<BadgeProps> = ({
   count,
   text,
   iconName,

--- a/src/components/Badge/Badge.types.ts
+++ b/src/components/Badge/Badge.types.ts
@@ -1,5 +1,5 @@
-import { Types as IconTypes, SSCIcons } from '../Icon/Icon.types';
-import { BadgeVariants } from './Badge.enums';
+import type { Types as IconTypes, SSCIcons } from '../Icon/Icon.types';
+import type { BadgeVariants } from './Badge.enums';
 
 export type BadgeVariant = typeof BadgeVariants[keyof typeof BadgeVariants];
 

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ActionsArray, BannerProps } from './Banner.types';
+
 import { action } from '@storybook/addon-actions';
 
 import Banner from './Banner';
 import { BannerVariants } from './Banner.enums';
-import { ActionsArray, BannerProps } from './Banner.types';
 import { generateControl } from '../../utils/tests/storybook';
 
 export default {

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,16 +1,18 @@
-import React, { useMemo } from 'react';
+import type { FC, MouseEvent } from 'react';
+import type { BannerProps } from './Banner.types';
+import type {
+  AbsoluteLinkActionKind,
+  RelativeLinkActionKind,
+} from '../../types/action.types';
+
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useContainerQuery } from 'react-container-query';
 import { isNonEmptyArray, noop } from 'ramda-adjunct';
 import cls from 'classnames';
 
-import { BannerProps } from './Banner.types';
-import {
-  AbsoluteLinkActionKind,
-  ActionKindsPropType,
-  RelativeLinkActionKind,
-} from '../../types/action.types';
+import { ActionKindsPropType } from '../../types/action.types';
 import * as CustomPropTypes from '../../types/customPropTypes';
 import { BannerVariants } from './Banner.enums';
 import { Button } from '../Button';
@@ -58,11 +60,7 @@ const Text = styled(BaseText)<{ $variant?: BannerProps['variant'] }>`
 
 const CHANGE_LAYOUT_BREAKPOINT = 'change-banner-layout';
 
-const BannerContent: React.FC<BannerProps> = ({
-  variant,
-  children,
-  actions,
-}) => (
+const BannerContent: FC<BannerProps> = ({ variant, children, actions }) => (
   <>
     <Text $variant={variant} as="div" size={TextSizes.md}>
       {children}
@@ -74,9 +72,9 @@ const BannerContent: React.FC<BannerProps> = ({
             key={action.name}
             $variant={variant}
             color={ButtonColors.secondary}
-            href={(action as AbsoluteLinkActionKind<[React.MouseEvent]>).href}
+            href={(action as AbsoluteLinkActionKind<[MouseEvent]>).href}
             name={action.name}
-            to={(action as RelativeLinkActionKind<[React.MouseEvent]>).to}
+            to={(action as RelativeLinkActionKind<[MouseEvent]>).to}
             variant={ButtonVariants.text}
             onClick={action.onClick}
           >
@@ -88,7 +86,7 @@ const BannerContent: React.FC<BannerProps> = ({
   </>
 );
 
-const Banner: React.FC<BannerProps> = ({
+const Banner: FC<BannerProps> = ({
   children,
   variant = BannerVariants.info,
   actions,

--- a/src/components/Banner/Banner.types.ts
+++ b/src/components/Banner/Banner.types.ts
@@ -1,11 +1,10 @@
-import React from 'react';
-
-import { BaseToastBannerProps } from '../_internal/BaseToastBanner/BaseToastBanner.types';
-import { ActionKinds } from '../../types/action.types';
+import type { MouseEvent, MouseEventHandler } from 'react';
+import type { BaseToastBannerProps } from '../_internal/BaseToastBanner/BaseToastBanner.types';
+import type { ActionKinds } from '../../types/action.types';
 
 export type ActionsArray = readonly [
-  ActionKinds<[React.MouseEvent]>?,
-  ActionKinds<[React.MouseEvent]>?,
+  ActionKinds<[MouseEvent]>?,
+  ActionKinds<[MouseEvent]>?,
 ];
 
 type BaseBannerProps = Omit<BaseToastBannerProps, 'onClose'> & {
@@ -14,7 +13,7 @@ type BaseBannerProps = Omit<BaseToastBannerProps, 'onClose'> & {
 
 export type BannerProps = BaseBannerProps & {
   isDismissable?: boolean;
-  onClose?: React.MouseEventHandler;
+  onClose?: MouseEventHandler;
   __hasPagination?: boolean;
   __onPrev?: () => void;
   __onNext?: () => void;

--- a/src/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/src/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { BreadcrumbItemProps } from './Breadcrumbs.types';
+import type { SSCIcons } from '../Icon/Icon.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { isNotUndefined } from 'ramda-adjunct';
 
-import { BreadcrumbItemProps } from './Breadcrumbs.types';
 import { getFontWeight } from '../../utils/helpers';
 import { Text, TextEnums } from '../typographyLegacy/Text';
 import { TextSizes } from '../typographyLegacy/Text/Text.enums';
 import { Button } from '../Button';
 import { SSCIconNames } from '../../theme/icons/icons.enums';
-import type { SSCIcons } from '../Icon/Icon.types';
 
 export const BreadcrumbLink = styled(Button)`
   font-weight: ${getFontWeight('regular')};
@@ -21,7 +22,7 @@ const ListItem = styled.li`
   list-style-type: none;
 `;
 
-const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
+const BreadcrumbItem: FC<BreadcrumbItemProps> = ({
   children,
   isSelected = false,
   to = undefined,

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { BreadcrumbsProps } from './Breadcrumbs.types';
+
 import { MemoryRouter } from 'react-router-dom';
 
-import { BreadcrumbsProps } from './Breadcrumbs.types';
 import Breadcrumbs from './Breadcrumbs';
 import BreadcrumbItem from './BreadcrumbItem';
 

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 
 import { renderWithProviders } from '../../utils/tests/renderWithProviders';
 import BreadcrumbItem from './BreadcrumbItem';

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,18 +1,20 @@
-import * as React from 'react';
+import type { FC, MouseEvent, ReactElement, ReactNode } from 'react';
+import type {
+  BreadcrumbItemProps,
+  BreadcrumbsProps,
+} from './Breadcrumbs.types';
+import type { ActionKinds } from '../../types/action.types';
+
 import PropTypes from 'prop-types';
 import { slice } from 'ramda';
 import styled from 'styled-components';
 import { isNilOrEmpty, isNotNilOrEmpty } from 'ramda-adjunct';
 import cls from 'classnames';
+import { Children, cloneElement, isValidElement } from 'react';
 
-import type {
-  BreadcrumbItemProps,
-  BreadcrumbsProps,
-} from './Breadcrumbs.types';
 import { SSCIconNames } from '../../theme/icons/icons.enums';
 import { Icon } from '../Icon';
 import { DropdownMenu } from '../_internal/BaseDropdownMenu';
-import { ActionKinds } from '../../types/action.types';
 import { getColor, getFontSize, pxToRem } from '../../utils';
 import { ColorTypes, SpaceSizes } from '../../theme';
 import { Inline } from '../layout';
@@ -47,7 +49,7 @@ const itemsAfterCollapse = 3;
 const itemsBeforeCollapse = 1;
 
 // Build list of breadcrumbs interspersing a separator
-const insertSeparators = (items: React.ReactElement[]) => {
+const insertSeparators = (items: ReactElement[]) => {
   return items.reduce((prev, current, index) => {
     if (index < items.length - 1) {
       return [
@@ -84,8 +86,8 @@ const renderDropdown = (actions: ActionKinds<React.MouseEvent[]>[]) => (
 
 // this renders the list of items only when the count of the actions is bigger than 2
 const renderItemsBeforeAndAfter = (
-  allItems: React.ReactNode[],
-  allDropdownActions: ActionKinds<React.MouseEvent[]>[],
+  allItems: ReactNode[],
+  allDropdownActions: ActionKinds<MouseEvent[]>[],
 ) => {
   const dropdown = renderDropdown(allDropdownActions);
   return [
@@ -95,33 +97,30 @@ const renderItemsBeforeAndAfter = (
   ];
 };
 
-const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
+const Breadcrumbs: FC<BreadcrumbsProps> = ({
   children,
   className,
   ...props
 }) => {
-  const allItems = React.Children.map(children, (breadcrumbItem) => {
-    if (!React.isValidElement(breadcrumbItem)) {
+  const allItems = Children.map(children, (breadcrumbItem) => {
+    if (!isValidElement(breadcrumbItem)) {
       return null;
     }
 
-    return React.cloneElement(
-      breadcrumbItem as React.ReactElement<BreadcrumbItemProps>,
-      {
-        isSelected:
-          isNilOrEmpty(breadcrumbItem.props.to) &&
-          isNilOrEmpty(breadcrumbItem.props.href),
-        ...props,
-      },
-    );
+    return cloneElement(breadcrumbItem as ReactElement<BreadcrumbItemProps>, {
+      isSelected:
+        isNilOrEmpty(breadcrumbItem.props.to) &&
+        isNilOrEmpty(breadcrumbItem.props.href),
+      ...props,
+    });
   });
 
   const allDropdownActions = slice(
     itemsBeforeCollapse,
     -Math.abs(itemsAfterCollapse),
   )(
-    React.Children.toArray(children).map((breadcrumbItem) => {
-      if (!React.isValidElement(breadcrumbItem)) {
+    Children.toArray(children).map((breadcrumbItem) => {
+      if (!isValidElement(breadcrumbItem)) {
         return null;
       }
       return {

--- a/src/components/Breadcrumbs/Breadcrumbs.types.ts
+++ b/src/components/Breadcrumbs/Breadcrumbs.types.ts
@@ -1,7 +1,7 @@
 import type { To } from 'history';
-
+import type { ReactNode } from 'react';
 import type { SSCIcons } from '../Icon/Icon.types';
-import { LinkProps } from '../typographyLegacy/Link/Link.types';
+import type { LinkProps } from '../typographyLegacy/Link/Link.types';
 
 export interface BreadcrumbItemProps extends Omit<LinkProps, 'color'> {
   /**
@@ -19,6 +19,6 @@ export interface BreadcrumbsProps {
   /**
    * The list of breadcrumb items
    */
-  children: React.ReactNode[];
+  children: ReactNode[];
   className?: string;
 }

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ButtonProps } from './Button.types';
 
 import { SSCIconNames } from '../../theme/icons/icons.enums';
 import { generateControl } from '../../utils/tests/storybook';
 import { Inline, Stack } from '../layout';
 import Button from './Button';
-import { ButtonProps } from './Button.types';
 import { ButtonColors, ButtonVariants } from './Button.enums';
 import { SpaceSizes } from '../../theme';
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { ButtonProps } from './Button.types';
 
-import { ButtonProps } from './Button.types';
 import { BaseButton } from '../_internal/BaseButton';
 
-const Button: React.FC<ButtonProps> = BaseButton;
+const Button: FC<ButtonProps> = BaseButton;
 
 export default Button;

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -1,3 +1,3 @@
-import { BaseButtonProps } from '../_internal/BaseButton/BaseButton.types';
+import type { BaseButtonProps } from '../_internal/BaseButton/BaseButton.types';
 
 export type ButtonProps = Omit<BaseButtonProps, 'size'>;

--- a/src/components/Callout/Callout.stories.tsx
+++ b/src/components/Callout/Callout.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { CalloutProps } from './Callout.types';
 
 import Callout from './Callout';
-import { CalloutProps } from './Callout.types';
 import { Link, Strong } from '../typographyLegacy';
 
 export default {

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { CalloutProps } from './Callout.types';
+import type { SSCIcons } from '../Icon/Icon.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
-import { CalloutProps } from './Callout.types';
 import { ColorTypes, SpaceSizes } from '../../theme';
 import { getColor, getFontSize, getRadii, pxToRem } from '../../utils';
 import { Inline, Padbox } from '../layout';
 import { Text } from '../typographyLegacy';
 import { Icon } from '../Icon';
 import { TextSizes } from '../typographyLegacy/Text/Text.enums';
-import { SSCIcons } from '../Icon/Icon.types';
 import { SSCIconNames } from '../../theme/icons/icons.enums';
 import { CLX_COMPONENT } from '../../theme/constants';
 
@@ -30,7 +31,7 @@ const Container = styled(Padbox)`
   border-radius: ${getRadii('default')};
 `;
 
-const Callout: React.FC<CalloutProps> = ({
+const Callout: FC<CalloutProps> = ({
   children,
   icon = SSCIconNames.lightbulb,
 }) => (

--- a/src/components/Callout/Callout.types.ts
+++ b/src/components/Callout/Callout.types.ts
@@ -1,7 +1,6 @@
-import React, { PropsWithChildren } from 'react';
-
-import { SSCIcons } from '../Icon/Icon.types';
+import type { PropsWithChildren, ReactNode } from 'react';
+import type { SSCIcons } from '../Icon/Icon.types';
 
 export type CalloutProps = PropsWithChildren<{
-  icon: React.ReactNode | SSCIcons;
+  icon: ReactNode | SSCIcons;
 }>;

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { CardActionsProps, CardProps } from './Card.types';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 
@@ -9,7 +10,6 @@ import CardHeader, { CardIconButton } from './CardHeader';
 import CardActions from './CardActions';
 import CardContent from './CardContent';
 import CardMedia from './CardMedia';
-import { CardActionsProps, CardProps } from './Card.types';
 import { Icon } from '../Icon';
 import { UserAvatar } from '../UserAvatar';
 import { Grid, Stack } from '../layout';

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import type { SpaceSize } from '../../theme/space.types';
+import type { CardProps, CardWrapperProps } from './Card.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { pipe, prop } from 'ramda';
 import cls from 'classnames';
+import { forwardRef } from 'react';
 
 import { Padbox, Stack } from '../layout';
 import { getColor, getRadii, getShadow, getSpace, getToken } from '../../utils';
-import { SpaceSize } from '../../theme/space.types';
-import { CardProps, CardWrapperProps } from './Card.types';
 import { CLX_COMPONENT } from '../../theme/constants';
 
 const InteractiveCard = css`
@@ -55,7 +56,7 @@ export const CardContainer = styled.div<{
     ${pipe(prop('horizontalPadding'), getSpace)};
 `;
 
-const Card = React.forwardRef<HTMLDivElement, CardProps>(
+const Card = forwardRef<HTMLDivElement, CardProps>(
   ({ children, shouldAlignLastItemToBottom = false, as, ...props }, ref) => {
     let domTag;
     if (props.onClick) {

--- a/src/components/Card/Card.types.ts
+++ b/src/components/Card/Card.types.ts
@@ -1,17 +1,16 @@
-import { DefaultTheme } from 'styled-components';
-import { ReactComponentLike } from 'prop-types';
-import React from 'react';
-
-import { SpaceSize } from '../../theme/space.types';
-import { ActionKinds } from '../../types/action.types';
-import { SSCIcons, Types } from '../Icon/Icon.types';
+import type { DefaultTheme } from 'styled-components';
+import type { ReactComponentLike } from 'prop-types';
+import type { CSSProperties, MouseEvent, ReactNode } from 'react';
+import type { SpaceSize } from '../../theme/space.types';
+import type { ActionKinds } from '../../types/action.types';
+import type { SSCIcons, Types } from '../Icon/Icon.types';
 
 export interface CardActionsProps {
   /**
    * List of available actions for the Card footer (maximal number of actions is 2)
    */
   actions: ActionKinds<
-    React.MouseEvent[],
+    MouseEvent[],
     void,
     {
       isDisabled?: boolean;
@@ -23,7 +22,7 @@ export interface CardActionsProps {
   /**
    * Adornment placed on the right side.
    */
-  rightAdornment: React.ReactNode;
+  rightAdornment: ReactNode;
 }
 
 export interface CardHeaderProps {
@@ -38,7 +37,7 @@ export interface CardHeaderProps {
   /**
    * List of available actions in the dropdown menu
    */
-  actions?: ActionKinds<React.MouseEvent[]>[];
+  actions?: ActionKinds<MouseEvent[]>[];
   /**
    * Actions menu aria label
    */
@@ -46,7 +45,7 @@ export interface CardHeaderProps {
   /**
    * Adornment placed on the left side.
    */
-  leftAdornment?: React.ReactNode;
+  leftAdornment?: ReactNode;
   /**
    *  Callback called when help button is clicked. Determines whether the help button is rendered or not.
    */
@@ -54,7 +53,7 @@ export interface CardHeaderProps {
   /**
    * Node that shows as a tooltip on help button hover. Determines whether the help button is rendered or not.
    */
-  helpTooltip?: React.ReactNode;
+  helpTooltip?: ReactNode;
   /**
    * Title max number of lines.
    */
@@ -74,7 +73,7 @@ export interface CardMediaProps {
   /**
    * Custom css `style` attribute
    */
-  style?: React.CSSProperties;
+  style?: CSSProperties;
   /**
    * Alternative text from media elements
    */
@@ -91,7 +90,7 @@ export interface CardMediaWrapperProps {
 }
 
 export interface CardProps {
-  children: React.ReactNode;
+  children: ReactNode;
   as?: ReactComponentLike;
   onClick?: (event: Event) => void;
   to?: string;

--- a/src/components/Card/CardActions.tsx
+++ b/src/components/Card/CardActions.tsx
@@ -1,20 +1,22 @@
-import React from 'react';
+import type { MouseEvent } from 'react';
+import type {
+  AbsoluteLinkActionKind,
+  RelativeLinkActionKind,
+} from '../../types/action.types';
+import type { CardActionsProps } from './Card.types';
+
 import PropTypes from 'prop-types';
 import { isNonEmptyString } from 'ramda-adjunct';
+import { forwardRef } from 'react';
 
 import { Inline } from '../layout';
 import { SpaceSizes } from '../../theme';
 import { Button, ButtonEnums } from '../Button';
 import * as CustomPropTypes from '../../types/customPropTypes';
-import {
-  AbsoluteLinkActionKind,
-  ActionKindsPropType,
-  RelativeLinkActionKind,
-} from '../../types/action.types';
-import { CardActionsProps } from './Card.types';
+import { ActionKindsPropType } from '../../types/action.types';
 import { CardContainer } from './Card';
 
-const CardActions = React.forwardRef<HTMLDivElement, CardActionsProps>(
+const CardActions = forwardRef<HTMLDivElement, CardActionsProps>(
   ({ actions, rightAdornment = null }, ref) => (
     <CardContainer
       horizontalPadding={SpaceSizes.mdPlus}
@@ -32,11 +34,11 @@ const CardActions = React.forwardRef<HTMLDivElement, CardActionsProps>(
               key={action.name}
               aria-label={action.ariaLabel}
               data-interactive="true"
-              href={(action as AbsoluteLinkActionKind<[React.MouseEvent]>).href}
+              href={(action as AbsoluteLinkActionKind<[MouseEvent]>).href}
               iconName={action.iconName}
               iconType={action.iconType}
               isDisabled={action.isDisabled}
-              to={(action as RelativeLinkActionKind<[React.MouseEvent]>).to}
+              to={(action as RelativeLinkActionKind<[MouseEvent]>).to}
               variant={ButtonEnums.ButtonVariants.text}
               onClick={action.onClick}
             >

--- a/src/components/Card/CardContent.tsx
+++ b/src/components/Card/CardContent.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import type { PropsWithChildren } from 'react';
+
+import { forwardRef } from 'react';
 
 import { SpaceSizes } from '../../theme';
 import { CardContainer } from './Card';
 
-const CardContent = React.forwardRef<
+const CardContent = forwardRef<
   HTMLDivElement,
-  React.PropsWithChildren<Record<string, unknown>>
+  PropsWithChildren<Record<string, unknown>>
 >(({ children, ...props }, ref) => (
   <CardContainer
     ref={ref}

--- a/src/components/Card/CardHeader.tsx
+++ b/src/components/Card/CardHeader.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import type { CardHeaderProps } from './Card.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { any } from 'ramda';
 import { isNotNil, isNotUndefined } from 'ramda-adjunct';
+import { forwardRef } from 'react';
 
 import { ActionKindsPropType } from '../../types/action.types';
 import { SSCIconNames } from '../../theme/icons/icons.enums';
@@ -12,7 +14,6 @@ import { DropdownMenu } from '../_internal/BaseDropdownMenu';
 import { Inline, Padbox, Stack } from '../layout';
 import { Heading, Text } from '../typographyLegacy';
 import { Icon } from '../Icon';
-import { CardHeaderProps } from './Card.types';
 import { CardContainer } from './Card';
 import { Tooltip } from '../Tooltip';
 
@@ -76,7 +77,7 @@ const ButtonsArea = styled.div`
   align-items: flex-start;
   margin-right: calc(${getSpace(SpaceSizes.sm)} * -1) !important;
 `;
-const CardHeader = React.forwardRef<HTMLDivElement, CardHeaderProps>(
+const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
   (
     {
       actions,

--- a/src/components/Card/CardMedia.tsx
+++ b/src/components/Card/CardMedia.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { HTMLProps, PropsWithChildren, ReactElement } from 'react';
+import type { CardMediaProps, CardMediaWrapperProps } from './Card.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { includes } from 'ramda';
@@ -6,7 +8,6 @@ import { isNotUndefined } from 'ramda-adjunct';
 
 import { getSpace } from '../../utils';
 import { SpaceSizes } from '../../theme';
-import { CardMediaProps, CardMediaWrapperProps } from './Card.types';
 
 const CardMediaWrapper = styled.div<CardMediaWrapperProps>`
   display: block;
@@ -34,9 +35,7 @@ function CardMedia<El extends HTMLElement = HTMLDivElement>({
   style,
   alt,
   ...props
-}: React.PropsWithChildren<
-  CardMediaProps & React.HTMLProps<El>
->): React.ReactElement {
+}: PropsWithChildren<CardMediaProps & HTMLProps<El>>): ReactElement {
   const isMediaComponent = includes(as, MEDIA_COMPONENTS);
   const isImageComponent = includes(as, IMAGE_COMPONENTS);
   const hasMediaSrc = isNotUndefined(mediaSrc);

--- a/src/components/CloseButton/CloseButton.stories.tsx
+++ b/src/components/CloseButton/CloseButton.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/CloseButton/CloseButton.tsx
+++ b/src/components/CloseButton/CloseButton.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
+import type {
+  AlignmentWrapperProps,
+  CloseButtonProps,
+  CloseButtonWrapperProps,
+} from './CloseButton.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { transparentize } from 'polished';
 import cls from 'classnames';
+import { forwardRef } from 'react';
 
 import { SSCIconNames } from '../../theme/icons/icons.enums';
 import { Icon } from '../Icon';
 import { SpaceSizes } from '../../theme';
 import { getColor, getNegativeSpace, getRadii, getSpace } from '../../utils';
-import {
-  AlignmentWrapperProps,
-  CloseButtonProps,
-  CloseButtonWrapperProps,
-} from './CloseButton.types';
 import { CLX_COMPONENT } from '../../theme/constants';
 
 const AlignmentWrapper = styled.div<AlignmentWrapperProps>`
@@ -58,7 +59,7 @@ const CloseButtonWrapper = styled.button<CloseButtonWrapperProps>`
   }
 `;
 
-const CloseButton = React.forwardRef<HTMLButtonElement, CloseButtonProps>(
+const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(
   (
     {
       onClose,

--- a/src/components/CloseButton/CloseButton.types.ts
+++ b/src/components/CloseButton/CloseButton.types.ts
@@ -1,4 +1,5 @@
-import { SpaceSize } from '../../theme/space.types';
+import type { MouseEventHandler } from 'react';
+import type { SpaceSize } from '../../theme/space.types';
 
 export type AlignmentWrapperProps = {
   $marginCompensation?: SpaceSize;
@@ -9,7 +10,7 @@ export interface CloseButtonProps {
   /**
    * Callback called when the close button is clicked
    */
-  onClose: React.MouseEventHandler;
+  onClose: MouseEventHandler;
   /**
    *
    */

--- a/src/components/Collapsible/Collapsible.stories.tsx
+++ b/src/components/Collapsible/Collapsible.stories.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ReactChild } from 'react';
+import type { CollapsibleProps } from './Collapsible.types';
+
 import { action } from '@storybook/addon-actions';
-import { Meta, Story } from '@storybook/react/types-6-0';
 
 import Collapsible from './Collapsible';
-import { CollapsibleProps } from './Collapsible.types';
 
 export default {
   component: Collapsible,
   title: 'components/Collapsible',
 } as Meta;
 
-export const Playground: Story<
-  CollapsibleProps & { children: React.ReactChild }
-> = (args) => <Collapsible {...args} />;
+export const Playground: Story<CollapsibleProps & { children: ReactChild }> = (
+  args,
+) => <Collapsible {...args} />;
 Playground.args = {
   title: 'playground',
   subject: 'Collapsible',

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -1,4 +1,7 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import type { CollapsibleProps } from './Collapsible.types';
+
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { includes } from 'ramda';
@@ -9,7 +12,6 @@ import { getColor, getRadii, pxToRem } from '../../utils';
 import { Icon } from '../Icon';
 import { Strong, Text } from '../typographyLegacy';
 import { TextSizes, TextVariants } from '../typographyLegacy/Text/Text.enums';
-import { CollapsibleProps } from './Collapsible.types';
 import { Padbox } from '../layout/Padbox';
 import { Inline } from '../layout/Inline';
 import { SpaceSizes } from '../../theme/space.enums';
@@ -51,7 +53,7 @@ const StyledIcon = styled(Icon).withConfig<{ isRotated: boolean }>({
   ${({ isRotated }) => isRotated && 'transform: rotate(90deg);'}
 `;
 
-const Collapsible: React.FC<CollapsibleProps> = ({
+const Collapsible: FC<CollapsibleProps> = ({
   children,
   className,
   defaultIsOpened = false,

--- a/src/components/Collapsible/Collapsible.types.ts
+++ b/src/components/Collapsible/Collapsible.types.ts
@@ -1,7 +1,9 @@
+import type { ReactNode } from 'react';
+
 export interface CollapsibleProps {
   className?: string;
   defaultIsOpened?: boolean;
   subject?: string;
-  title: React.ReactNode;
+  title: ReactNode;
   onOpen?: () => void;
 }

--- a/src/components/ControlDropdown/ControlDropdown.stories.tsx
+++ b/src/components/ControlDropdown/ControlDropdown.stories.tsx
@@ -1,10 +1,11 @@
-import React, { useRef } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ControlDropdownProps } from './ControlDropdown.types';
+
+import { useRef } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { Paragraph } from '../typographyLegacy';
 import { Center } from '../layout';
-import { ControlDropdownProps } from './ControlDropdown.types';
 import ControlDropdown from './ControlDropdown';
 
 export default {

--- a/src/components/ControlDropdown/ControlDropdown.tsx
+++ b/src/components/ControlDropdown/ControlDropdown.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import type { FC } from 'react';
+import type { ControlDropdownProps } from './ControlDropdown.types';
+
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { isNotUndefined } from 'ramda-adjunct';
 
@@ -8,12 +11,11 @@ import { Button } from '../Button';
 import { ButtonVariants } from '../Button/Button.enums';
 import { CloseButton } from '../CloseButton';
 import { H4 } from '../typographyLegacy';
-import { ControlDropdownProps } from './ControlDropdown.types';
 import { ControlDropdownPlacements } from './ControlDropdown.enums';
 import ControlledDropdown from '../Dropdown/ControlledDropdown';
 import { CLX_COMPONENT } from '../../theme/constants';
 
-const ControlDropdown: React.FC<ControlDropdownProps> = ({
+const ControlDropdown: FC<ControlDropdownProps> = ({
   children,
   title,
   parentRef,

--- a/src/components/ControlDropdown/ControlDropdown.types.ts
+++ b/src/components/ControlDropdown/ControlDropdown.types.ts
@@ -1,12 +1,11 @@
-import React from 'react';
-
-import { Placements } from '../Dropdown/Dropdown.types';
+import type { MutableRefObject } from 'react';
+import type { Placements } from '../Dropdown/Dropdown.types';
 
 export interface ControlDropdownProps {
   /**
    * Reference to opener button used to calculate correct position
    */
-  parentRef: React.MutableRefObject<HTMLSpanElement>;
+  parentRef: MutableRefObject<HTMLSpanElement>;
   /**
    * Title in dropdown header
    */

--- a/src/components/Datatable/BatchModule/BatchActions/BatchActions.stories.tsx
+++ b/src/components/Datatable/BatchModule/BatchActions/BatchActions.stories.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { BatchActionsProps } from './BatchActions.types';
+
 import { MemoryRouter } from 'react-router-dom';
 
 import BatchActions from './BatchActions';
 import { actionsMock } from '../../mocks/actions';
-import { BatchActionsProps } from './BatchActions.types';
 
 export default {
   title: 'components/Datatable/internalComponents/BatchModule/BatchActions',

--- a/src/components/Datatable/BatchModule/BatchActions/BatchActions.test.tsx
+++ b/src/components/Datatable/BatchModule/BatchActions/BatchActions.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 
 import { renderWithProviders } from '../../../../utils/tests/renderWithProviders';
 import { DatatableStore, datatableInitialState } from '../../Datatable.store';

--- a/src/components/Datatable/BatchModule/BatchActions/BatchActions.tsx
+++ b/src/components/Datatable/BatchModule/BatchActions/BatchActions.tsx
@@ -1,4 +1,13 @@
-import React, { useCallback } from 'react';
+import type { FC } from 'react';
+import type {
+  AbsoluteLinkActionKind,
+  ActionWithSubactions,
+  RelativeLinkActionKind,
+} from '../../../../types/action.types';
+import type { BatchActionsProps } from './BatchActions.types';
+import type { BatchActionArgs } from '../../Datatable.types';
+
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { map, pipe } from 'ramda';
@@ -12,15 +21,8 @@ import { BaseButton } from '../../../_internal/BaseButton';
 import { ButtonVariants } from '../../../Button/Button.enums';
 import { Icon } from '../../../Icon';
 import { ActionPropType } from '../../types/Action.types';
-import {
-  AbsoluteLinkActionKind,
-  ActionWithSubactions,
-  RelativeLinkActionKind,
-} from '../../../../types/action.types';
 import { DropdownMenu } from '../../../_internal/BaseDropdownMenu';
-import { BatchActionsProps } from './BatchActions.types';
 import { DatatableStore } from '../../Datatable.store';
-import { BatchActionArgs } from '../../Datatable.types';
 import { Tooltip } from '../../../Tooltip';
 
 const BatchActionButton = styled(BaseButton)`
@@ -29,7 +31,7 @@ const BatchActionButton = styled(BaseButton)`
   height: ${pipe(getFormStyle('fieldHeight'), pxToRem)};
 `;
 
-const BatchActions: React.FC<BatchActionsProps> = ({ actions }) => {
+const BatchActions: FC<BatchActionsProps> = ({ actions }) => {
   const { selectedIds, hasExclusiveSelection } = DatatableStore.useState(
     (s) => ({
       selectedIds: s.selectedIds,

--- a/src/components/Datatable/BatchModule/BatchActions/BatchActions.types.ts
+++ b/src/components/Datatable/BatchModule/BatchActions/BatchActions.types.ts
@@ -1,5 +1,5 @@
-import { Action } from '../../types/Action.types';
-import { BatchActionArgs } from '../../Datatable.types';
+import type { Action } from '../../types/Action.types';
+import type { BatchActionArgs } from '../../Datatable.types';
 
 export interface BatchActionsProps {
   actions: Action<BatchActionArgs>[];

--- a/src/components/Datatable/BatchModule/BatchModule.stories.tsx
+++ b/src/components/Datatable/BatchModule/BatchModule.stories.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { BatchModuleProps } from './BatchModule.types';
+
+import { useEffect } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { actionsMock } from '../mocks/actions';
 import BatchModule from './BatchModule';
-import { BatchModuleProps } from './BatchModule.types';
 import { DatatableStore } from '../Datatable.store';
 import { defaultTableConfig } from '../defaultConfigs';
 

--- a/src/components/Datatable/BatchModule/BatchModule.tsx
+++ b/src/components/Datatable/BatchModule/BatchModule.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import type { FC } from 'react';
+import type { BatchModuleProps } from './BatchModule.types';
+
+import { useEffect, useState } from 'react';
 import { all, isEmpty } from 'ramda';
 import { isNonEmptyArray } from 'ramda-adjunct';
 import styled from 'styled-components';
@@ -12,14 +15,13 @@ import { ColumnsControls } from '../components/ColumnsControls';
 import { ControlButton } from '../components/ControlButton';
 import { BatchActions } from './BatchActions';
 import { ElementCounter } from './ElementCounter';
-import { BatchModuleProps } from './BatchModule.types';
 import { DatatableStore } from '../Datatable.store';
 
 const BatchModuleWrapper = styled(Padbox)`
   min-height: ${pxToRem(64)};
 `;
 
-const BatchModule: React.FC<BatchModuleProps> = ({
+const BatchModule: FC<BatchModuleProps> = ({
   actions,
   hasSelection,
   hasOnlyPerPageSelection,

--- a/src/components/Datatable/BatchModule/BatchModule.types.ts
+++ b/src/components/Datatable/BatchModule/BatchModule.types.ts
@@ -1,5 +1,5 @@
-import { BatchActionsProps } from './BatchActions/BatchActions.types';
-import { ElementCounterProps } from './ElementCounter/ElementCounter.types';
+import type { BatchActionsProps } from './BatchActions/BatchActions.types';
+import type { ElementCounterProps } from './ElementCounter/ElementCounter.types';
 
 export interface BatchModuleProps
   extends BatchActionsProps,

--- a/src/components/Datatable/BatchModule/ElementCounter/ElementCounter.stories.tsx
+++ b/src/components/Datatable/BatchModule/ElementCounter/ElementCounter.stories.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ElementCounterProps } from './ElementCounter.types';
+
+import { useEffect } from 'react';
 
 import ElementCounter from './ElementCounter';
 import { DatatableStore } from '../../Datatable.store';
-import { ElementCounterProps } from './ElementCounter.types';
 import { defaultTableConfig } from '../../defaultConfigs';
 
 export default {

--- a/src/components/Datatable/BatchModule/ElementCounter/ElementCounter.test.tsx
+++ b/src/components/Datatable/BatchModule/ElementCounter/ElementCounter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import ElementCounter, { getCounterContent } from './ElementCounter';

--- a/src/components/Datatable/BatchModule/ElementCounter/ElementCounter.tsx
+++ b/src/components/Datatable/BatchModule/ElementCounter/ElementCounter.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import type { FC, ReactElement } from 'react';
+import type { ElementCounterProps } from './ElementCounter.types';
+
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { isPositive } from 'ramda-adjunct';
 import styled from 'styled-components';
@@ -16,7 +19,6 @@ import { DropdownMenu } from '../../../_internal/BaseDropdownMenu';
 import { Icon } from '../../../Icon';
 import { SSCIconNames } from '../../../../theme/icons/icons.enums';
 import { DatatableStore } from '../../Datatable.store';
-import { ElementCounterProps } from './ElementCounter.types';
 import { Inline, Padbox } from '../../../layout';
 import { SpaceSizes } from '../../../../theme';
 import { PaddingTypes } from '../../../layout/Padbox/Padbox.enums';
@@ -41,7 +43,7 @@ const SelectionButton = styled.button`
 export const getCounterContent = (
   totalLength: number,
   selectedLength = 0,
-): React.ReactElement => (
+): ReactElement => (
   <span data-testid="counter-content">
     {isPositive(selectedLength) && isPositive(totalLength)
       ? `${abbreviateNumber(selectedLength)} of ${abbreviateNumber(
@@ -72,7 +74,7 @@ const CounterText = styled(Text).attrs(() => ({
   line-height: ${pxToRem(24)};
 `;
 
-const ElementCounter: React.FC<ElementCounterProps> = ({
+const ElementCounter: FC<ElementCounterProps> = ({
   dataSize,
   hasSelection,
   hasOnlyPerPageSelection,

--- a/src/components/Datatable/ControlsModule/ControlsModule.stories.tsx
+++ b/src/components/Datatable/ControlsModule/ControlsModule.stories.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ControlsModuleProps } from './ControlsModule.types';
+import type { Data } from '../../_internal/BaseTable/mocks/types';
+
 import { mergeDeepRight } from 'ramda';
 import { action } from '@storybook/addon-actions';
 
 import { fields } from '../../Filters/mocks/options';
 import { defaultControlsConfig } from '../defaultConfigs';
 import ControlsModule from './ControlsModule';
-import { ControlsModuleProps } from './ControlsModule.types';
 import { useColumnsControls } from '../hooks/useColumnsControls';
 import { simpleColumns } from '../../_internal/BaseTable/mocks/columns';
-import { Data } from '../../_internal/BaseTable/mocks/types';
 
 export default {
   title: 'components/Datatable/internalComponents/ControlsModule',

--- a/src/components/Datatable/ControlsModule/ControlsModule.test.tsx
+++ b/src/components/Datatable/ControlsModule/ControlsModule.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/Datatable/ControlsModule/ControlsModule.tsx
+++ b/src/components/Datatable/ControlsModule/ControlsModule.tsx
@@ -1,4 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import type { ReactElement } from 'react';
+import type {
+  ControlState,
+  Controls,
+  ControlsLocalState,
+  ControlsModuleProps,
+} from './ControlsModule.types';
+import type { Filter } from '../../Filters/Filters.types';
+
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { all, isEmpty, map, mergeDeepRight, omit, pipe, zipObj } from 'ramda';
 import { isNonEmptyArray, isNotNilOrEmpty } from 'ramda-adjunct';
@@ -10,14 +19,7 @@ import { SSCIconNames } from '../../../theme/icons/icons.enums';
 import { ColumnsControls } from '../components/ColumnsControls';
 import { ControlButton } from '../components/ControlButton';
 import { DatatableStore } from '../Datatable.store';
-import {
-  ControlState,
-  Controls,
-  ControlsConfigPropType,
-  ControlsLocalState,
-  ControlsModuleProps,
-} from './ControlsModule.types';
-import { Filter } from '../../Filters/Filters.types';
+import { ControlsConfigPropType } from './ControlsModule.types';
 import { ControlTypes } from './ControlsModule.enums';
 import { SpaceSizes } from '../../../theme';
 import { PaddingTypes } from '../../layout/Padbox/Padbox.enums';
@@ -68,7 +70,7 @@ function ControlsModule<D extends Record<string, unknown>>({
   // defaultViews,
   onCancelLoading,
   onControlToggle,
-}: ControlsModuleProps<D>): React.ReactElement {
+}: ControlsModuleProps<D>): ReactElement {
   const {
     onClose: onFilteringClose,
     onApply: onFilteringApply,

--- a/src/components/Datatable/ControlsModule/ControlsModule.types.ts
+++ b/src/components/Datatable/ControlsModule/ControlsModule.types.ts
@@ -1,9 +1,12 @@
-import PropTypes from 'prop-types';
 import type { IdType } from 'react-table';
+import type { SearchProps } from '../components/Search/Search.types';
+import type { FiltersProps } from '../../Filters/Filters.types';
+import type { ControlTypes } from './ControlsModule.enums';
 
-import { SearchPropType, SearchProps } from '../components/Search/Search.types';
-import { FiltersPropType, FiltersProps } from '../../Filters/Filters.types';
-import { ControlTypes } from './ControlsModule.enums';
+import PropTypes from 'prop-types';
+
+import { FiltersPropType } from '../../Filters/Filters.types';
+import { SearchPropType } from '../components/Search/Search.types';
 
 export type Controls = typeof ControlTypes[keyof typeof ControlTypes];
 

--- a/src/components/Datatable/Datatable.store.ts
+++ b/src/components/Datatable/Datatable.store.ts
@@ -1,7 +1,7 @@
-import { Store, registerInDevtools } from 'pullstate';
-import { IdType, SortingRule } from 'react-table';
+import type { IdType, SortingRule } from 'react-table';
+import type { Filter } from '../Filters/Filters.types';
 
-import { Filter } from '../Filters/Filters.types';
+import { Store, registerInDevtools } from 'pullstate';
 
 export type DatatableStoreShape<
   D extends Record<string, unknown> = Record<string, unknown>,

--- a/src/components/Datatable/Datatable.stories.tsx
+++ b/src/components/Datatable/Datatable.stories.tsx
@@ -1,11 +1,13 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { Data } from '../_internal/BaseTable/mocks/types';
+import type { DatatableProps } from './Datatable.types';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { action } from '@storybook/addon-actions';
-import { Meta, Story } from '@storybook/react/types-6-0';
 import MockDate from 'mockdate';
 
 import assets from '../_internal/BaseTable/mocks/ipAssets.json';
-import { Data } from '../_internal/BaseTable/mocks/types';
 import { simpleColumns } from '../_internal/BaseTable/mocks/columns';
 import { comparisonTable } from '../_internal/BaseTable/docs';
 import { controlsConfig } from './mocks/controls';
@@ -20,7 +22,6 @@ import {
   TableConfigType,
 } from './Datatable.storiesTypes';
 import Datatable from './Datatable';
-import { DatatableProps } from './Datatable.types';
 
 MockDate.set('2021-03-31T00:00:00Z');
 

--- a/src/components/Datatable/Datatable.test.tsx
+++ b/src/components/Datatable/Datatable.test.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import type { Column } from 'react-table';
+
+import { useState } from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Column } from 'react-table';
 import { filter } from 'ramda';
 
 import { renderWithProviders } from '../../utils/tests/renderWithProviders';

--- a/src/components/Datatable/Datatable.tsx
+++ b/src/components/Datatable/Datatable.tsx
@@ -1,10 +1,14 @@
-import React, { useEffect } from 'react';
+import type { ReactElement } from 'react';
+import type { IdType } from 'react-table';
+import type { TableConfig } from './Table/Table.types';
+import type { DatatableProps } from './Datatable.types';
+
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useDeepCompareMemo } from 'use-deep-compare';
 import { assoc, assocPath, fromPairs, map, pipe } from 'ramda';
 import { isNotUndefined, noop } from 'ramda-adjunct';
-import { IdType } from 'react-table';
 
 import { getColor, getRadii } from '../../utils';
 import { Padbox } from '../layout';
@@ -16,8 +20,7 @@ import { mergeControlsConfig, mergeTableConfig } from './defaultConfigs';
 import { ControlsModule } from './ControlsModule';
 import { BatchModule } from './BatchModule';
 import { Table } from './Table';
-import { TableConfig, TableConfigPropType } from './Table/Table.types';
-import { DatatableProps } from './Datatable.types';
+import { TableConfigPropType } from './Table/Table.types';
 import { DatatableStore, datatableInitialState } from './Datatable.store';
 import { useColumnsControls } from './hooks/useColumnsControls';
 import { CLX_COMPONENT } from '../../theme/constants';
@@ -53,7 +56,7 @@ function Datatable<D extends Record<string, unknown>>({
   controlsConfig = {},
   tableConfig = {},
   resetSelectionFn,
-}: DatatableProps<D>): React.ReactElement {
+}: DatatableProps<D>): ReactElement {
   const [persistedState, setPersistedState] = useLocalStorageState(
     `datatable_${id}`,
   );

--- a/src/components/Datatable/Datatable.types.ts
+++ b/src/components/Datatable/Datatable.types.ts
@@ -1,10 +1,9 @@
-import { Column, SortingRule } from 'react-table';
-
-import { PrimaryKey } from '../_internal/BaseTable/BaseTable.types';
-import { Filter } from '../Filters/Filters.types';
-import { ControlsConfig } from './ControlsModule/ControlsModule.types';
-import { TableConfig } from './Table/Table.types';
-import { Action } from './types/Action.types';
+import type { Column, SortingRule } from 'react-table';
+import type { PrimaryKey } from '../_internal/BaseTable/BaseTable.types';
+import type { Filter } from '../Filters/Filters.types';
+import type { ControlsConfig } from './ControlsModule/ControlsModule.types';
+import type { TableConfig } from './Table/Table.types';
+import type { Action } from './types/Action.types';
 
 type OnDataFetchArgs<D> = {
   pageSize: number;

--- a/src/components/Datatable/DatatableTests.stories.tsx
+++ b/src/components/Datatable/DatatableTests.stories.tsx
@@ -1,5 +1,8 @@
-import React, { useEffect } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { Data } from '../_internal/BaseTable/mocks/types';
+import type { DatatableProps } from './Datatable.types';
+
+import { useEffect } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import MockDate from 'mockdate';
 
@@ -8,10 +11,8 @@ import {
   fields as filtersFields,
   state as filtersState,
 } from '../Filters/mocks/options';
-import { Data } from '../_internal/BaseTable/mocks/types';
 import assets from '../_internal/BaseTable/mocks/ipAssets.json';
 import { simpleColumns } from '../_internal/BaseTable/mocks/columns';
-import { DatatableProps } from './Datatable.types';
 import { DatatableStore, datatableInitialState } from './Datatable.store';
 import { tableActionsMock } from './mocks/actions';
 

--- a/src/components/Datatable/Table/Table.reducer.ts
+++ b/src/components/Datatable/Table/Table.reducer.ts
@@ -1,4 +1,4 @@
-import { ActionType, IdType, SortingRule, TableState } from 'react-table';
+import type { ActionType, IdType, SortingRule, TableState } from 'react-table';
 
 type TableRecord = Record<string, unknown>;
 

--- a/src/components/Datatable/Table/Table.stories.tsx
+++ b/src/components/Datatable/Table/Table.stories.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { TableProps } from './Table.types';
+import type { Data } from '../../_internal/BaseTable/mocks/types';
+
+import { useEffect } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { omit } from 'ramda';
 import MockDate from 'mockdate';
 
 import Table from './Table';
-import { TableProps } from './Table.types';
-import { Data } from '../../_internal/BaseTable/mocks/types';
 import assets from '../../_internal/BaseTable/mocks/ipAssets.json';
 import { defaultTableConfig } from '../defaultConfigs';
 import { simpleColumns } from '../../_internal/BaseTable/mocks/columns';

--- a/src/components/Datatable/Table/Table.test.tsx
+++ b/src/components/Datatable/Table/Table.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { Column } from 'react-table';
+
 import { act, screen, waitFor } from '@testing-library/react';
-import { Column } from 'react-table';
 import userEvent from '@testing-library/user-event';
 
 import { renderWithProviders } from '../../../utils/tests/renderWithProviders';

--- a/src/components/Datatable/Table/Table.tsx
+++ b/src/components/Datatable/Table/Table.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import type { ReactElement } from 'react';
+import type { CellProps, Column, IdType, SortingRule } from 'react-table';
+import type { TableProps } from './Table.types';
+
+import { useCallback, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 import {
-  CellProps,
-  Column,
-  IdType,
-  SortingRule,
   useColumnOrder,
   useFlexLayout,
   usePagination,
@@ -44,7 +44,6 @@ import { selectionColumn } from './columns/selectionColumn';
 import { LoadingOverlay } from './components';
 import { Padbox, Stack } from '../../layout';
 import { getColor, pxToRem } from '../../../utils';
-import { TableProps } from './Table.types';
 import { SELECTION_COLUMN_ID } from '../../_internal/BaseTable/renderers/renderers.enums';
 import { H4, Paragraph } from '../../typographyLegacy';
 import { TextSizes } from '../../typographyLegacy/Text/Text.enums';
@@ -80,7 +79,7 @@ const collectSelectedIds = <D,>(
 
 const renderDefaultCell = <D extends Record<string, unknown>>(
   props: CellProps<D>,
-): React.ReactElement => <CellRenderer<D> {...props} />;
+): ReactElement => <CellRenderer<D> {...props} />;
 
 function Table<D extends Record<string, unknown>>({
   columns,
@@ -106,7 +105,7 @@ function Table<D extends Record<string, unknown>>({
   defaultColumnOrder,
   defaultHiddenColumns,
   pageButtonsCount,
-}: TableProps<D> & { pageButtonsCount?: number }): React.ReactElement {
+}: TableProps<D> & { pageButtonsCount?: number }): ReactElement {
   const tableDataSize = useMemo(
     () => (hasServerSidePagination ? dataSize : data.length),
     [hasServerSidePagination, dataSize, data],
@@ -125,8 +124,7 @@ function Table<D extends Record<string, unknown>>({
       width: 150,
       maxWidth: 400,
       nullCondition: stubFalse,
-      Cell: (props: CellProps<D>): React.ReactElement =>
-        renderDefaultCell<D>(props),
+      Cell: (props: CellProps<D>): ReactElement => renderDefaultCell<D>(props),
       cellType: 'text',
     }),
     [],

--- a/src/components/Datatable/Table/Table.types.ts
+++ b/src/components/Datatable/Table/Table.types.ts
@@ -1,12 +1,14 @@
-import PropTypes, { ReactComponentLike } from 'prop-types';
-import { Column, IdType, SortingRule } from 'react-table';
-
-import { RendererColumnOptions } from '../../_internal/BaseTable/renderers/renderers.types';
-import {
+import type { ReactComponentLike } from 'prop-types';
+import type { Column, IdType, SortingRule } from 'react-table';
+import type { RendererColumnOptions } from '../../_internal/BaseTable/renderers/renderers.types';
+import type {
   PrimaryKey,
   RowAction,
-  RowActionKindsPropType,
 } from '../../_internal/BaseTable/BaseTable.types';
+
+import PropTypes from 'prop-types';
+
+import { RowActionKindsPropType } from '../../_internal/BaseTable/BaseTable.types';
 
 export type OnSelectFn<D> = (
   ids: IdType<D>[],

--- a/src/components/Datatable/Table/columns/selectionColumn.tsx
+++ b/src/components/Datatable/Table/columns/selectionColumn.tsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useRef } from 'react';
-import { CellProps, HeaderProps, TableToggleCommonProps } from 'react-table';
+import type { ChangeEvent, MutableRefObject, ReactElement } from 'react';
+import type {
+  CellProps,
+  HeaderProps,
+  TableToggleCommonProps,
+} from 'react-table';
+
+import { forwardRef, useEffect, useRef } from 'react';
 
 import {
   CellTypes,
@@ -12,11 +18,11 @@ interface IndeterminateCheckbox extends TableToggleCommonProps {
   id: string;
   isDisabled?: boolean;
 }
-const IndeterminateCheckbox = React.forwardRef(
+const IndeterminateCheckbox = forwardRef(
   (
     { id, indeterminate, isDisabled = false, ...rest }: IndeterminateCheckbox,
-    ref: React.MutableRefObject<HTMLInputElement>,
-  ): React.ReactElement => {
+    ref: MutableRefObject<HTMLInputElement>,
+  ): ReactElement => {
     const defaultRef = useRef<HTMLInputElement>();
     const resolvedRef = ref || defaultRef;
     useEffect(() => {
@@ -48,7 +54,7 @@ export const selectionColumn = {
     isMultiSelect,
     dispatch,
     state: { selectedRowIds: tableSelectedRowIds },
-  }: HeaderProps<Record<string, unknown>>): React.ReactElement => {
+  }: HeaderProps<Record<string, unknown>>): ReactElement => {
     if (dataSize === 0) return null;
 
     const selectedLength = Object.keys(tableSelectedRowIds).length;
@@ -78,7 +84,7 @@ export const selectionColumn = {
     isMultiSelect,
     row,
     dispatch,
-  }: CellProps<Record<string, unknown>>): React.ReactElement => {
+  }: CellProps<Record<string, unknown>>): ReactElement => {
     const id = `row-${row.id}`;
 
     return (
@@ -87,7 +93,7 @@ export const selectionColumn = {
         {...row.getToggleRowSelectedProps({
           ...(!isMultiSelect
             ? {
-                onChange(e: React.ChangeEvent<HTMLInputElement>) {
+                onChange(e: ChangeEvent<HTMLInputElement>) {
                   dispatch({
                     type: actions.toggleSingleRowSelected,
                     id: row.id,

--- a/src/components/Datatable/Table/components/LoadingOverlay.tsx
+++ b/src/components/Datatable/Table/components/LoadingOverlay.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { LoadingOverlayProps } from './LoadingOverlay.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 import { getColor, getRadii } from '../../../../utils';
-import { LoadingOverlayProps } from './LoadingOverlay.types';
 import { Spinner } from '../../../Spinner';
 import { Button } from '../../../Button';
 import { Inline, Padbox } from '../../../layout';
@@ -48,7 +49,7 @@ const LoadingBackground = styled.div`
   opacity: 0.75;
 `;
 
-const LoadingOverlay: React.FC<LoadingOverlayProps> = ({
+const LoadingOverlay: FC<LoadingOverlayProps> = ({
   isCancelable,
   onCancel,
 }) => (

--- a/src/components/Datatable/Table/components/LoadingOverlay.types.ts
+++ b/src/components/Datatable/Table/components/LoadingOverlay.types.ts
@@ -1,4 +1,6 @@
+import type { MouseEvent } from 'react';
+
 export interface LoadingOverlayProps {
-  onCancel: (event: React.MouseEvent<HTMLElement>) => void;
+  onCancel: (event: MouseEvent<HTMLElement>) => void;
   isCancelable?: boolean;
 }

--- a/src/components/Datatable/Table/components/NoMatchingData.tsx
+++ b/src/components/Datatable/Table/components/NoMatchingData.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { FC } from 'react';
+
 import styled from 'styled-components';
 
 import { pxToRem } from '../../../../utils';
@@ -13,7 +14,7 @@ const ListItem = styled.li`
   }
 `;
 
-const NoMatchingData: React.FC = () => (
+const NoMatchingData: FC = () => (
   <>
     <H4 margin={{ top: 0, bottom: 0.8 }}>
       No items match your current filters

--- a/src/components/Datatable/Table/components/TableCheckbox.tsx
+++ b/src/components/Datatable/Table/components/TableCheckbox.tsx
@@ -1,10 +1,12 @@
-import React, { forwardRef } from 'react';
+import type { MutableRefObject, ReactElement } from 'react';
+import type { TableCheckboxProps } from './TableCheckbox.types';
+
+import { forwardRef } from 'react';
 import cls from 'classnames';
 
 import * as checked from '../../../../theme/icons/check';
 import * as indeterminate from '../../../../theme/icons/minus';
 import { Checkbox } from '../../../forms';
-import { TableCheckboxProps } from './TableCheckbox.types';
 
 const generateIconProps = ({ width, height, svgPathData }) => ({
   viewBox: `0 0 ${width} ${height}`,
@@ -30,8 +32,8 @@ const TableCheckbox = forwardRef(
       style,
       ...props
     }: TableCheckboxProps,
-    ref: React.MutableRefObject<HTMLInputElement>,
-  ): React.ReactElement => (
+    ref: MutableRefObject<HTMLInputElement>,
+  ): ReactElement => (
     <div className="ds-table-checkbox">
       <input
         ref={ref}

--- a/src/components/Datatable/Table/components/TableCheckbox.types.ts
+++ b/src/components/Datatable/Table/components/TableCheckbox.types.ts
@@ -1,3 +1,3 @@
-import { CheckboxProps } from '../../../forms/Checkbox/Checkbox.types';
+import type { CheckboxProps } from '../../../forms/Checkbox/Checkbox.types';
 
 export type TableCheckboxProps = CheckboxProps;

--- a/src/components/Datatable/components/ColumnsControls/ColumnsControls.stories.tsx
+++ b/src/components/Datatable/components/ColumnsControls/ColumnsControls.stories.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ColumnsControlsProps } from './ColumnsControls.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import ColumnsControls from './ColumnsControls';
 import { simpleColumns } from '../../../_internal/BaseTable/mocks/columns';
 import { useColumnsControls } from '../../hooks/useColumnsControls';
-import { ColumnsControlsProps } from './ColumnsControls.types';
 
 export default {
   title:

--- a/src/components/Datatable/components/ColumnsControls/ColumnsControls.tsx
+++ b/src/components/Datatable/components/ColumnsControls/ColumnsControls.tsx
@@ -1,4 +1,7 @@
-import React, { useRef } from 'react';
+import type { FC } from 'react';
+import type { ColumnsControlsProps } from './ColumnsControls.types';
+
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { pluck } from 'ramda';
 import { noop } from 'ramda-adjunct';
@@ -8,7 +11,6 @@ import { SortableList } from '../../../SortableList';
 import { DatatableStore } from '../../Datatable.store';
 import { useColumnOrder } from './hooks/useColumnOrder';
 import { useColumnVisibility } from './hooks/useColumnVisibility';
-import { ColumnsControlsProps } from './ColumnsControls.types';
 import { Inline } from '../../../layout';
 import { Text } from '../../../typographyLegacy';
 import { TextSizes } from '../../../typographyLegacy/Text/Text.enums';
@@ -16,7 +18,7 @@ import { Switch } from '../../../forms';
 import { SwitchSizes } from '../../../forms/Switch/Switch.enums';
 import { SpaceSizes } from '../../../../theme';
 
-const ColumnsControls: React.FC<ColumnsControlsProps> = ({
+const ColumnsControls: FC<ColumnsControlsProps> = ({
   children,
   isOpen = false,
   onClose = noop,

--- a/src/components/Datatable/components/ColumnsControls/hooks/useColumnOrder.ts
+++ b/src/components/Datatable/components/ColumnsControls/hooks/useColumnOrder.ts
@@ -1,8 +1,11 @@
+import type { Dispatch, SetStateAction } from 'react';
+import type { DatatableStoreShape } from '../../../Datatable.store';
+
 import { useEffect, useState } from 'react';
 import { comparator, keys, lt, sort } from 'ramda';
 import deepEqual from 'fast-deep-equal';
 
-import { DatatableStore, DatatableStoreShape } from '../../../Datatable.store';
+import { DatatableStore } from '../../../Datatable.store';
 
 export const compare =
   (order: string[]) =>
@@ -32,7 +35,7 @@ export const sortColumns = (
 
 export const useColumnOrder = (): {
   orderedColumns: string[];
-  setLocalColumnOrder: React.Dispatch<React.SetStateAction<string[]>>;
+  setLocalColumnOrder: Dispatch<SetStateAction<string[]>>;
   storeOrderedColumns: () => void;
   reinitializeOrderedColumns: () => void;
   resetOrderedColumns: () => void;

--- a/src/components/Datatable/components/ControlButton/ControlButton.stories.tsx
+++ b/src/components/Datatable/components/ControlButton/ControlButton.stories.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ControlButtonProps } from './ControlButton.types';
+
 import { action } from '@storybook/addon-actions';
 
 import { Inline, Padbox } from '../../../layout';
 import { SSCIconNames } from '../../../../theme/icons/icons.enums';
 import ControlButton from './ControlButton';
-import { ControlButtonProps } from './ControlButton.types';
 
 export default {
   title: 'components/Datatable/internalComponents/ControlsModule/ControlButton',

--- a/src/components/Datatable/components/ControlButton/ControlButton.tsx
+++ b/src/components/Datatable/components/ControlButton/ControlButton.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { SSCIcons } from '../../../Icon/Icon.types';
+import type { ControlButtonProps } from './ControlButton.types';
+
 import PropTypes from 'prop-types';
 
 import { SSCIconNames } from '../../../../theme/icons/icons.enums';
 import { Button } from '../../../Button';
 import { Badge } from '../../../Badge';
 import { Inline } from '../../../layout';
-import { SSCIcons } from '../../../Icon/Icon.types';
-import { ControlButtonProps } from './ControlButton.types';
 
-const ControlButton: React.FC<ControlButtonProps> = ({
+const ControlButton: FC<ControlButtonProps> = ({
   label,
   iconName,
   appliedFilters = 0,

--- a/src/components/Datatable/components/ControlButton/ControlButton.types.ts
+++ b/src/components/Datatable/components/ControlButton/ControlButton.types.ts
@@ -1,4 +1,4 @@
-import { SSCIcons } from '../../../Icon/Icon.types';
+import type { SSCIcons } from '../../../Icon/Icon.types';
 
 export interface ControlButtonProps {
   label: string;

--- a/src/components/Datatable/components/Search/Search.test.tsx
+++ b/src/components/Datatable/components/Search/Search.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable testing-library/await-async-query */
-import React from 'react';
+
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/Datatable/components/Search/Search.tsx
+++ b/src/components/Datatable/components/Search/Search.tsx
@@ -1,12 +1,15 @@
-import React, { useState } from 'react';
+import type { FC, KeyboardEventHandler } from 'react';
+import type { SearchProps } from './Search.types';
 
-import { SearchPropType, SearchProps } from './Search.types';
+import { useState } from 'react';
+
+import { SearchPropType } from './Search.types';
 import { Error } from '../../../forms/Message';
 import { validatePattern } from '../../../Filters/helpers';
 import { Stack } from '../../../layout';
 import { SearchBar } from '../../../forms';
 
-const Search: React.FC<SearchProps> = ({
+const Search: FC<SearchProps> = ({
   onSearch,
   onClear,
   placeholder = 'Search',
@@ -29,7 +32,7 @@ const Search: React.FC<SearchProps> = ({
     await onSearch(searchQuery);
     setIsSearching(false);
   };
-  const handleKeyUp: React.KeyboardEventHandler = (e) => {
+  const handleKeyUp: KeyboardEventHandler = (e) => {
     const target = e.target as HTMLInputElement;
     const hasError = validatePattern(target);
     const searchValidQuery = () => {

--- a/src/components/Datatable/components/Search/Search.types.ts
+++ b/src/components/Datatable/components/Search/Search.types.ts
@@ -1,10 +1,11 @@
-import PropTypes from 'prop-types';
+import type { InputHTMLAttributes } from 'react';
+import type { InputProps } from '../../../forms/Input/Input.types';
 
-import { InputProps } from '../../../forms/Input/Input.types';
+import PropTypes from 'prop-types';
 
 export interface SearchProps
   extends InputProps,
-    React.InputHTMLAttributes<HTMLInputElement> {
+    InputHTMLAttributes<HTMLInputElement> {
   onSearch: (query: string) => void | Promise<void>;
   onClear: () => void;
   placeholder?: string;

--- a/src/components/Datatable/defaultConfigs.ts
+++ b/src/components/Datatable/defaultConfigs.ts
@@ -1,8 +1,9 @@
+import type { ControlsConfig } from './ControlsModule/ControlsModule.types';
+import type { TableConfig } from './Table/Table.types';
+
 import { mergeDeepRight } from 'ramda';
 import { noop } from 'ramda-adjunct';
 
-import { ControlsConfig } from './ControlsModule/ControlsModule.types';
-import { TableConfig } from './Table/Table.types';
 import { NoMatchingData } from './Table/components';
 import { NoData } from '../_internal/BaseTable';
 

--- a/src/components/Datatable/hooks/useColumnsControls.ts
+++ b/src/components/Datatable/hooks/useColumnsControls.ts
@@ -1,6 +1,7 @@
+import type { Column, IdType } from 'react-table';
+
 import { useEffect } from 'react';
 import { allPass, reduce } from 'ramda';
-import { Column, IdType } from 'react-table';
 import { isNotFunction, isNotUndefined } from 'ramda-adjunct';
 import { useDeepCompareEffect } from 'use-deep-compare';
 

--- a/src/components/Datatable/hooks/useDataFetch.ts
+++ b/src/components/Datatable/hooks/useDataFetch.ts
@@ -1,8 +1,9 @@
+import type { OnDataFetchFn } from '../Datatable.types';
+
 import { useEffect } from 'react';
 import { pick, propEq, when } from 'ramda';
 
 import { DatatableStore } from '../Datatable.store';
-import { OnDataFetchFn } from '../Datatable.types';
 
 export const useDataFetch = <D>(onDataFetch: OnDataFetchFn<D>): void => {
   useEffect(() => {

--- a/src/components/Datatable/hooks/useTableRowSelect.ts
+++ b/src/components/Datatable/hooks/useTableRowSelect.ts
@@ -1,8 +1,9 @@
+import type { IdType } from 'react-table';
+import type { OnSelectFn } from '../Table/Table.types';
+
 import { useEffect } from 'react';
-import { IdType } from 'react-table';
 
 import { DatatableStore } from '../Datatable.store';
-import { OnSelectFn } from '../Table/Table.types';
 
 export const useTableRowSelect = <D>(
   onSelect: OnSelectFn<D>,

--- a/src/components/Datatable/mocks/actions.tsx
+++ b/src/components/Datatable/mocks/actions.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import type { BatchActionArgs } from '../Datatable.types';
+import type { Action } from '../types/Action.types';
+import type { ActionKinds } from '../../../types/action.types';
+
 import { action } from '@storybook/addon-actions';
 
-import { BatchActionArgs } from '../Datatable.types';
-import { Action } from '../types/Action.types';
-import { ActionKinds } from '../../../types/action.types';
 import Inline from '../../layout/Inline/Inline';
 import Icon from '../../Icon/Icon';
 import { Tooltip } from '../../Tooltip';

--- a/src/components/Datatable/types/Action.types.ts
+++ b/src/components/Datatable/types/Action.types.ts
@@ -1,9 +1,12 @@
+import type {
+  ActionKinds,
+  ActionWithSubactions,
+} from '../../../types/action.types';
+
 import PropTypes from 'prop-types';
 
 import {
   AbsoluteLinkActionKindPropType,
-  ActionKinds,
-  ActionWithSubactions,
   ActionWithSubactionsPropType,
   HandlerActionKindPropType,
   RelativeLinkActionKindPropType,

--- a/src/components/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-
-import DateRangePicker from './DateRangePicker';
-import {
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type {
   BaseDateRange,
   BaseDateRangePickerProps,
 } from '../_internal/BaseDateRangePicker/BaseDateRangePicker.types';
+
+import { useState } from 'react';
+
+import DateRangePicker from './DateRangePicker';
 
 export default {
   title: 'components/DateRangePicker',

--- a/src/components/DateRangePicker/DateRangePicker.test.tsx
+++ b/src/components/DateRangePicker/DateRangePicker.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { DrawerProps } from './Drawer.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 
 import Drawer from './Drawer';
-import { DrawerProps } from './Drawer.types';
 import { DrawerSizes } from './Drawer.enums';
 import { SemanticModal } from '../SemanticModal';
 import { H2, Link, Paragraph, Text } from '../typographyLegacy';

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react';
-import React from 'react';
 
 import { renderWithProviders } from '../../utils/tests/renderWithProviders';
 import Drawer from './Drawer';

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,11 +1,12 @@
-import React, { forwardRef, useContext } from 'react';
+import type { DrawerProps } from './Drawer.types';
+
+import { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import usePortal from 'react-cool-portal';
 import styled from 'styled-components';
 import { isNotUndefined } from 'ramda-adjunct';
 import cls from 'classnames';
 
-import { DrawerProps } from './Drawer.types';
 import { DrawerSizes } from './Drawer.enums';
 import { useLockBodyScroll } from '../../hooks/useLockBodyScroll';
 import { useOuterClick } from '../../hooks/useOuterCallback';

--- a/src/components/Drawer/Drawer.types.ts
+++ b/src/components/Drawer/Drawer.types.ts
@@ -1,16 +1,15 @@
-import React from 'react';
-
-import { DrawerSizes } from './Drawer.enums';
+import type { MouseEventHandler, ReactNode } from 'react';
+import type { DrawerSizes } from './Drawer.enums';
 
 export type Sizes = typeof DrawerSizes[keyof typeof DrawerSizes];
 
 export interface DrawerProps {
-  children: React.ReactNode;
-  onClose: React.MouseEventHandler;
-  footer?: React.ReactNode;
+  children: ReactNode;
+  onClose: MouseEventHandler;
+  footer?: ReactNode;
   title: string;
   size?: Sizes;
-  adornment?: React.ReactNode;
+  adornment?: ReactNode;
   hasBackdrop?: boolean;
   className?: string;
   [key: string]: unknown;

--- a/src/components/Dropdown/ControlledDropdown.stories.tsx
+++ b/src/components/Dropdown/ControlledDropdown.stories.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { DropdownProps } from './Dropdown.types';
+
+import { useState } from 'react';
 
 import { Button } from '../Button';
 import ControlledDropdown from './ControlledDropdown';
-import { DropdownProps } from './Dropdown.types';
 import { PaddingTypes } from '../layout/Padbox/Padbox.enums';
 import { generateControl } from '../../utils/tests/storybook';
 import { CreatableSelect } from '../forms/Select';

--- a/src/components/Dropdown/ControlledDropdown.tsx
+++ b/src/components/Dropdown/ControlledDropdown.tsx
@@ -1,11 +1,13 @@
-import React, { forwardRef, useState } from 'react';
+import type { HTMLAttributes } from 'react';
+import type { ControlledDropdownProps } from './Dropdown.types';
+
+import { forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { SpaceSizes } from '../../theme';
 import { usePopup } from '../../hooks/usePopup';
 import { usePortal } from '../../hooks/usePortal';
 import { PaddingTypes } from '../layout/Padbox/Padbox.enums';
-import { ControlledDropdownProps } from './Dropdown.types';
 import DropdownPane from './DropdownPane';
 import { DropdownPlacements } from './Dropdown.enums';
 import { mergeRefs } from '../../utils/mergeRefs';
@@ -13,7 +15,7 @@ import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 const ControlledDropdown = forwardRef<
   HTMLDivElement,
-  ControlledDropdownProps & React.HTMLAttributes<HTMLDivElement>
+  ControlledDropdownProps & HTMLAttributes<HTMLDivElement>
 >(
   (
     {

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { DropdownProps } from './Dropdown.types';
+
 import { action } from '@storybook/addon-actions';
 
 import { Link, Paragraph } from '../typographyLegacy';
 import { Inline, Stack } from '../layout';
 import { Button } from '../Button';
 import Dropdown from './Dropdown';
-import { DropdownProps } from './Dropdown.types';
 import { PaddingTypes } from '../layout/Padbox/Padbox.enums';
 import { generateControl } from '../../utils/tests/storybook';
 import { CreatableSelect } from '../forms/Select';

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,16 +1,25 @@
-import React, { useEffect, useImperativeHandle, useRef, useState } from 'react';
+import type { FC, KeyboardEventHandler } from 'react';
+import type { DropdownProps } from './Dropdown.types';
+
+import {
+  cloneElement,
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { noop } from 'ramda-adjunct';
 import { Ref } from '@fluentui/react-component-ref';
 
 import { SpaceSizes } from '../../theme';
 import { PaddingTypes } from '../layout/Padbox/Padbox.enums';
-import { DropdownProps } from './Dropdown.types';
 import { DropdownPlacements, DropdownTriggerEvents } from './Dropdown.enums';
 import ControlledDropdown from './ControlledDropdown';
 import { CLX_COMPONENT } from '../../theme/constants';
 
-const Dropdown: React.FC<DropdownProps> = React.forwardRef(
+const Dropdown: FC<DropdownProps> = forwardRef(
   (
     {
       children,
@@ -80,7 +89,7 @@ const Dropdown: React.FC<DropdownProps> = React.forwardRef(
       togglePane();
     };
 
-    const handleTriggerOnKeyDown: React.KeyboardEventHandler = (e) => {
+    const handleTriggerOnKeyDown: KeyboardEventHandler = (e) => {
       if (!triggerEvents.includes('click')) {
         return;
       }
@@ -131,7 +140,7 @@ const Dropdown: React.FC<DropdownProps> = React.forwardRef(
     return (
       <>
         <Ref innerRef={setTriggerEl}>
-          {React.cloneElement(trigger, {
+          {cloneElement(trigger, {
             onClick: handleTriggerOnClick,
             onTouchStart: handleTriggerOnClick,
             onKeyDown: handleTriggerOnKeyDown,

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -1,8 +1,16 @@
-import { ReactElement } from 'react';
-
-import { SpaceSize } from '../../theme/space.types';
-import { PaddingType } from '../../utils/space';
-import { DropdownPlacements, DropdownTriggerEvents } from './Dropdown.enums';
+import type {
+  CSSProperties,
+  HTMLAttributes,
+  PropsWithChildren,
+  ReactElement,
+  Ref,
+} from 'react';
+import type { SpaceSize } from '../../theme/space.types';
+import type { PaddingType } from '../../utils/space';
+import type {
+  DropdownPlacements,
+  DropdownTriggerEvents,
+} from './Dropdown.enums';
 
 export type TriggerEvents =
   typeof DropdownTriggerEvents[keyof typeof DropdownTriggerEvents];
@@ -13,17 +21,17 @@ export interface DropdownPaneStyles {
   $isElevated?: boolean;
   $maxWidth: number | 'auto';
 }
-export type DropdownPaneProps = React.PropsWithChildren<
+export type DropdownPaneProps = PropsWithChildren<
   {
     isElevated: DropdownPaneStyles['$isElevated'];
     maxWidth: DropdownPaneStyles['$maxWidth'];
     onClickOut?: () => void;
     hasArrow: boolean;
     arrowRef: (el: HTMLElement) => void;
-    arrowStyles: React.CSSProperties;
+    arrowStyles: CSSProperties;
     contentPaddingSize: SpaceSize;
     contentPaddingType: PaddingType;
-  } & React.HTMLAttributes<HTMLDivElement>
+  } & HTMLAttributes<HTMLDivElement>
 >;
 
 interface BaseDropdownProps {
@@ -100,7 +108,7 @@ export interface DropdownProps extends BaseDropdownProps {
   /**
    * Imperative handle ref
    */
-  ref?: React.Ref<{
+  ref?: Ref<{
     togglePane: () => void;
     hidePane: () => void;
     showPane: () => void;

--- a/src/components/Dropdown/DropdownPane.tsx
+++ b/src/components/Dropdown/DropdownPane.tsx
@@ -1,4 +1,6 @@
-import React, { forwardRef } from 'react';
+import type { DropdownPaneProps, DropdownPaneStyles } from './Dropdown.types';
+
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { noop } from 'ramda-adjunct';
@@ -17,7 +19,6 @@ import { SpaceSizes } from '../../theme';
 import { useOuterClick } from '../../hooks/useOuterCallback';
 import { Padbox } from '../layout';
 import { PaddingTypes } from '../layout/Padbox/Padbox.enums';
-import { DropdownPaneProps, DropdownPaneStyles } from './Dropdown.types';
 
 export const Arrow = styled.div`
   visibility: hidden;

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { MouseEvent } from 'react';
+import type { DropdownMenuProps } from '../_internal/BaseDropdownMenu/DropdownMenu.types';
+import type { ActionKinds } from '../../types/action.types';
+
 import { MemoryRouter } from 'react-router-dom';
-import { Meta, Story } from '@storybook/react/types-6-0';
 import styled from 'styled-components';
 
 import DropdownMenu from '../_internal/BaseDropdownMenu/DropdownMenu';
 import { subactionsMock } from '../Datatable/mocks/actions';
-import { DropdownMenuProps } from '../_internal/BaseDropdownMenu/DropdownMenu.types';
 import { Inline, Padbox } from '../layout';
 import { pxToRem } from '../../utils';
-import { ActionKinds } from '../../types/action.types';
 
 const Wrapper = styled(Padbox)`
   margin-bottom: ${pxToRem(100)};
@@ -65,7 +66,7 @@ export const Default: Story<DropdownMenuProps> = (args) => (
   </Inline>
 );
 Default.args = {
-  actions: subactionsMock as unknown as ActionKinds<React.MouseEvent[]>[],
+  actions: subactionsMock as unknown as ActionKinds<MouseEvent[]>[],
 };
 Default.parameters = {
   screenshot: { skip: true },

--- a/src/components/FileSelector/FileSelector.stories.tsx
+++ b/src/components/FileSelector/FileSelector.stories.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { FileSelectorProps } from './FileSelector.types';
+
+import { useState } from 'react';
 import { isNonEmptyArray } from 'ramda-adjunct';
 import styled from 'styled-components';
 
 import FileSelector from './FileSelector';
-import { FileSelectorProps } from './FileSelector.types';
 import { FileSelectorSizes } from './FileSelector.enums';
 import { Inline, Padbox, Stack } from '../layout';
 import { SpaceSizes } from '../../theme/space.enums';

--- a/src/components/FileSelector/FileSelector.tsx
+++ b/src/components/FileSelector/FileSelector.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { FileSelectorProps } from './FileSelector.types';
+
 import styled, { css } from 'styled-components';
 import { useDropzone } from 'react-dropzone';
 import { omit } from 'ramda';
@@ -13,7 +14,6 @@ import { Button } from '../Button';
 import { ButtonVariants } from '../Button/Button.enums';
 import { Text } from '../typographyLegacy';
 import { TextSizes, TextVariants } from '../typographyLegacy/Text/Text.enums';
-import { FileSelectorProps } from './FileSelector.types';
 import { FileSelectorSizes } from './FileSelector.enums';
 import { CLX_COMPONENT } from '../../theme/constants';
 import { useLogger } from '../../hooks/useLogger';

--- a/src/components/FileSelector/FileSelector.types.ts
+++ b/src/components/FileSelector/FileSelector.types.ts
@@ -1,6 +1,6 @@
+import type { HTMLAttributes } from 'react';
 import type { DropzoneOptions } from 'react-dropzone';
-
-import { FileSelectorSizes } from './FileSelector.enums';
+import type { FileSelectorSizes } from './FileSelector.enums';
 
 type CustomFileSelectorProps = {
   /**
@@ -49,7 +49,7 @@ type CustomFileSelectorProps = {
   onFilesRejected?: DropzoneOptions['onDropRejected'];
 };
 
-type BaseFileSelectorProps = React.HTMLAttributes<HTMLDivElement> &
+type BaseFileSelectorProps = HTMLAttributes<HTMLDivElement> &
   Omit<
     DropzoneOptions,
     | 'disabled'

--- a/src/components/Filters/BottomBar/BottomBar.stories.tsx
+++ b/src/components/Filters/BottomBar/BottomBar.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { BottomBarProps } from './BottomBar.types';
 
 import BottomBar from './BottomBar';
-import { BottomBarProps } from './BottomBar.types';
 
 export default {
   component: BottomBar,

--- a/src/components/Filters/BottomBar/BottomBar.tsx
+++ b/src/components/Filters/BottomBar/BottomBar.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { BottomBarProps } from './BottomBar.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import { Inline } from '../../layout';
 import { Paragraph } from '../../typographyLegacy';
 import { Button } from '../../Button';
-import { BottomBarProps } from './BottomBar.types';
 import { getSpace } from '../../../utils';
 import { SpaceSizes } from '../../../theme';
 
@@ -13,7 +14,7 @@ const AddFilterButton = styled(Button)`
   padding-left: ${getSpace(SpaceSizes.sm)};
 `;
 
-const BottomBar: React.FC<BottomBarProps> = ({
+const BottomBar: FC<BottomBarProps> = ({
   onSubmit,
   onAdd,
   onClearAll,

--- a/src/components/Filters/BottomBar/BottomBar.types.ts
+++ b/src/components/Filters/BottomBar/BottomBar.types.ts
@@ -1,9 +1,11 @@
+import type { MouseEvent } from 'react';
+
 export interface BottomBarProps {
-  onAdd: (event: React.MouseEvent<HTMLElement>) => void;
-  onClearAll: (event: React.MouseEvent<HTMLElement>) => void;
-  onClose: (event: React.MouseEvent<HTMLElement>) => void;
-  onCancel: (event: React.MouseEvent<HTMLElement>) => void;
-  onSubmit: (event: React.MouseEvent<HTMLElement>) => void;
+  onAdd: (event: MouseEvent<HTMLElement>) => void;
+  onClearAll: (event: MouseEvent<HTMLElement>) => void;
+  onClose: (event: MouseEvent<HTMLElement>) => void;
+  onCancel: (event: MouseEvent<HTMLElement>) => void;
+  onSubmit: (event: MouseEvent<HTMLElement>) => void;
   hasUnappliedFilters: boolean;
   isLoading?: boolean;
   isCancelEnabled?: boolean;

--- a/src/components/Filters/DisabledOperator/DisabledOperator.tsx
+++ b/src/components/Filters/DisabledOperator/DisabledOperator.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { FC } from 'react';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -20,7 +21,7 @@ const Text = styled(BaseText)`
   line-height: unset;
 `;
 
-const DisabledOperator: React.FC = ({ children }) => (
+const DisabledOperator: FC = ({ children }) => (
   <Container paddingSize={SpaceSizes.md} paddingType={PaddingTypes.squish}>
     <Text size={TextSizes.md}>{children}</Text>
   </Container>

--- a/src/components/Filters/FilterRow/FilterRow.tsx
+++ b/src/components/Filters/FilterRow/FilterRow.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import type { FC, ReactNode } from 'react';
+import type { FilterRowProps, SplitFieldProps } from './FilterRow.types';
+import type { ComponentWithProps as ComponentWithPropsTypes } from '../Filters.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import {
@@ -29,11 +32,7 @@ import { TextSizes } from '../../typographyLegacy/Text/Text.enums';
 import { StateButton } from '../StateButton';
 import { SelectFilter } from '../components';
 import { DisabledOperator } from '../DisabledOperator';
-import { FilterRowProps, SplitFieldProps } from './FilterRow.types';
-import {
-  ComponentWithProps as ComponentWithPropsTypes,
-  FieldPropTypes,
-} from '../Filters.types';
+import { FieldPropTypes } from '../Filters.types';
 import { Operators } from '../Filters.enums';
 import { operatorOptions } from '../data/operatorOptions';
 import { pxToRem } from '../../../utils';
@@ -58,7 +57,7 @@ const Units = styled(Text)`
 `;
 
 export const getDefaultComponentValue = (
-  defaultConditionComponent: React.ReactNode | ComponentWithPropsTypes,
+  defaultConditionComponent: ReactNode | ComponentWithPropsTypes,
 ): string | undefined => {
   const componentDefaultValue = path(
     ['props', 'defaultValue'],
@@ -188,7 +187,7 @@ const renderComponent = (Component, value, onChange, onError, isInvalid) => {
   );
 };
 
-const FilterRow: React.FC<FilterRowProps> = ({
+const FilterRow: FC<FilterRowProps> = ({
   fields,
   index,
   onOperatorChange,

--- a/src/components/Filters/FilterRow/FilterRow.types.ts
+++ b/src/components/Filters/FilterRow/FilterRow.types.ts
@@ -1,6 +1,7 @@
-import { Field, Filter } from '../Filters.types';
-import { Option } from '../components/Select/Select.types';
-import { Operators } from '../Filters.enums';
+import type { MouseEventHandler } from 'react-select';
+import type { Field, Filter } from '../Filters.types';
+import type { Option } from '../components/Select/Select.types';
+import type { Operators } from '../Filters.enums';
 
 export interface SplitFieldProps {
   $width?: number;
@@ -18,7 +19,7 @@ export interface FilterRowProps extends Filter {
   ) => void;
   onConditionChange: (condition: string, value: string, index: number) => void;
   onValueChange: (value: string, index: number) => void;
-  onRemove: (index: number) => React.MouseEventHandler;
+  onRemove: (index: number) => MouseEventHandler;
   isDefaultState: boolean;
   isApplied: boolean;
   isLoading: boolean;

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 
 import Filters from './Filters';

--- a/src/components/Filters/Filters.test.tsx
+++ b/src/components/Filters/Filters.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import selectEvent from 'react-select-event';
 

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -1,4 +1,7 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import type { FC } from 'react';
+import type { Field, Filter, FiltersProps } from './Filters.types';
+
+import { useEffect, useMemo, useState } from 'react';
 import {
   allPass,
   any,
@@ -31,7 +34,7 @@ import { Padbox, Stack } from '../layout';
 import { FilterRow } from './FilterRow';
 import { getDefaultComponentValue } from './FilterRow/FilterRow';
 import { BottomBar } from './BottomBar';
-import { Field, Filter, FiltersPropType, FiltersProps } from './Filters.types';
+import { FiltersPropType } from './Filters.types';
 import { Operators } from './Filters.enums';
 import { SpaceSizes } from '../../theme';
 import { CLX_COMPONENT } from '../../theme/constants';
@@ -73,7 +76,7 @@ const FiltersBase = styled(Padbox)`
   flex-grow: 1;
 `;
 
-const Filters: React.FC<FiltersProps> = ({
+const Filters: FC<FiltersProps> = ({
   fields,
   state: stateFromProps,
   onApply,

--- a/src/components/Filters/Filters.types.ts
+++ b/src/components/Filters/Filters.types.ts
@@ -1,12 +1,17 @@
+import type { ReactNode } from 'react';
+import type {
+  BaseDateRange,
+  BaseDateRangePlaceholderProps,
+} from '../_internal/BaseDateRangePicker/BaseDateRangePicker.types';
+import type { Option } from './components/Select/Select.types';
+
 import PropTypes from 'prop-types';
 
 import {
-  BaseDateRange,
   BaseDateRangePickerPropTypes,
   BaseDateRangePlaceholderPropTypes,
-  BaseDateRangePlaceholderProps,
 } from '../_internal/BaseDateRangePicker/BaseDateRangePicker.types';
-import { Option, OptionPropType } from './components/Select/Select.types';
+import { OptionPropType } from './components/Select/Select.types';
 import { Operators } from './Filters.enums';
 
 type OperatorTypes = typeof Operators[keyof typeof Operators];
@@ -28,12 +33,12 @@ interface ComponentProps {
 }
 
 export interface ComponentWithProps {
-  component: React.ReactNode;
+  component: ReactNode;
   props: ComponentProps;
 }
 
 export interface Condition {
-  component: React.ReactNode | ComponentWithProps;
+  component: ReactNode | ComponentWithProps;
   label: string;
   value: string;
   isDefault?: boolean;

--- a/src/components/Filters/StateButton/StateButton.tsx
+++ b/src/components/Filters/StateButton/StateButton.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { StateButtonProps } from './StateButton.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -15,7 +17,6 @@ import {
   getRadii,
   pxToRem,
 } from '../../../utils';
-import { StateButtonProps } from './StateButton.types';
 import { useStateButtonIcon } from '../hooks/useStateButton';
 
 const Popup = styled(Padbox)`
@@ -65,7 +66,7 @@ const LightText = styled(Text)`
   font-weight: ${getFontWeight('medium')};
 `;
 
-const StateButton: React.FC<StateButtonProps> = ({
+const StateButton: FC<StateButtonProps> = ({
   index,
   onClick,
   isApplied = false,

--- a/src/components/Filters/StateButton/StateButton.types.ts
+++ b/src/components/Filters/StateButton/StateButton.types.ts
@@ -1,6 +1,8 @@
+import type { MouseEventHandler } from 'react';
+
 export interface StateButtonProps {
   index: number;
-  onClick: (index: number) => React.MouseEventHandler;
+  onClick: (index: number) => MouseEventHandler;
   isApplied?: boolean;
   isLoading?: boolean;
 }

--- a/src/components/Filters/components/Count/Count.stories.tsx
+++ b/src/components/Filters/components/Count/Count.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/Filters/components/Count/Count.tsx
+++ b/src/components/Filters/components/Count/Count.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { NumberProps } from '../Number/Number.types';
+
 import { isNonEmptyString } from 'ramda-adjunct';
 
 import { StyledNumber } from '../Number/Number';
 import { Error } from '../../../forms/Message';
 import { validateNumber } from '../../helpers';
-import { NumberPropTypes, NumberProps } from '../Number/Number.types';
+import { NumberPropTypes } from '../Number/Number.types';
 
-const Count: React.FC<NumberProps> = ({
+const Count: FC<NumberProps> = ({
   value = '',
   onChange,
   min,

--- a/src/components/Filters/components/DateRangePicker/DateRangePicker.stories.tsx
+++ b/src/components/Filters/components/DateRangePicker/DateRangePicker.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/Filters/components/Input/Input.stories.tsx
+++ b/src/components/Filters/components/Input/Input.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/Filters/components/Input/Input.tsx
+++ b/src/components/Filters/components/Input/Input.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { InputProps } from './Input.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { isNonEmptyString } from 'ramda-adjunct';
 import { pipe } from 'ramda';
 
-import { InputProps } from './Input.types';
 import { Error } from '../../../forms/Message';
 import {
   getFontSize,
@@ -53,7 +54,7 @@ export const StyledInput = styled.input<InputProps>`
     `}
 `;
 
-const Input: React.FC<InputProps> = ({
+const Input: FC<InputProps> = ({
   value = '',
   onChange,
   maxLength,

--- a/src/components/Filters/components/Input/Input.types.ts
+++ b/src/components/Filters/components/Input/Input.types.ts
@@ -1,6 +1,8 @@
+import type { ReactEventHandler } from 'react';
+
 export interface InputProps {
   value: string;
-  onChange: (event: React.ReactEventHandler) => void;
+  onChange: (event: ReactEventHandler) => void;
   placeholder?: string;
   isInvalid?: boolean;
   maxLength?: number;

--- a/src/components/Filters/components/Integer/Integer.stories.tsx
+++ b/src/components/Filters/components/Integer/Integer.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/Filters/components/Integer/Integer.tsx
+++ b/src/components/Filters/components/Integer/Integer.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { NumberProps } from '../Number/Number.types';
+
 import { isNonEmptyString } from 'ramda-adjunct';
 
 import { StyledNumber } from '../Number/Number';
 import { Error } from '../../../forms/Message';
 import { validateNumber } from '../../helpers';
-import { NumberPropTypes, NumberProps } from '../Number/Number.types';
+import { NumberPropTypes } from '../Number/Number.types';
 
-const Integer: React.FC<NumberProps> = ({
+const Integer: FC<NumberProps> = ({
   value = '',
   onChange,
   min,

--- a/src/components/Filters/components/Number/Number.stories.tsx
+++ b/src/components/Filters/components/Number/Number.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/Filters/components/Number/Number.tsx
+++ b/src/components/Filters/components/Number/Number.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { NumberProps } from './Number.types';
+
 import styled from 'styled-components';
 import { isNonEmptyString } from 'ramda-adjunct';
 
 import { StyledInput } from '../Input/Input';
 import { Error } from '../../../forms/Message';
 import { validateNumber } from '../../helpers';
-import { NumberPropTypes, NumberProps } from './Number.types';
+import { NumberPropTypes } from './Number.types';
 
 export const StyledNumber = styled(StyledInput)`
   &::-webkit-inner-spin-button,
@@ -16,7 +18,7 @@ export const StyledNumber = styled(StyledInput)`
   appearance: textfield;
 `;
 
-const Number: React.FC<NumberProps> = ({
+const Number: FC<NumberProps> = ({
   value = '',
   onChange,
   min,

--- a/src/components/Filters/components/Number/Number.types.ts
+++ b/src/components/Filters/components/Number/Number.types.ts
@@ -1,8 +1,10 @@
+import type { ReactEventHandler } from 'react';
+
 import PropTypes from 'prop-types';
 
 export interface NumberProps {
   value: string;
-  onChange: (event: React.ReactEventHandler) => void;
+  onChange: (event: ReactEventHandler) => void;
   min?: number;
   max?: number;
   placeholder?: string;

--- a/src/components/Filters/components/Select/Select.stories.tsx
+++ b/src/components/Filters/components/Select/Select.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/Filters/components/Select/Select.tsx
+++ b/src/components/Filters/components/Select/Select.tsx
@@ -1,17 +1,16 @@
-import React from 'react';
+import type { MultiValueProps, OptionTypeBase } from 'react-select';
+import type { FC } from 'react';
+import type { SelectProps } from './Select.types';
+
 import PropTypes from 'prop-types';
-import ReactSelect, {
-  MultiValueProps,
-  OptionTypeBase,
-  components,
-} from 'react-select';
+import ReactSelect, { components } from 'react-select';
 import { toString } from 'ramda';
 
 import Tag from '../TagsInput/Tag';
 import { IconTypes, SSCIconNames } from '../../../../theme/icons/icons.enums';
 import { Icon } from '../../../Icon';
 import { selectStyles } from './styles';
-import { OptionPropType, SelectProps } from './Select.types';
+import { OptionPropType } from './Select.types';
 
 function DropdownIndicator(props) {
   return (
@@ -21,12 +20,12 @@ function DropdownIndicator(props) {
   );
 }
 
-const MultiValue: React.FC<MultiValueProps<OptionTypeBase>> = (props) => {
+const MultiValue: FC<MultiValueProps<OptionTypeBase>> = (props) => {
   const { data, removeProps } = props;
   return <Tag value={data.label} onClose={removeProps.onClick} />;
 };
 
-const Select: React.FC<SelectProps> = (props) => {
+const Select: FC<SelectProps> = (props) => {
   const { value } = props;
 
   return (

--- a/src/components/Filters/components/Select/styles.ts
+++ b/src/components/Filters/components/Select/styles.ts
@@ -1,9 +1,10 @@
+import type { StylesConfig } from 'react-select';
+import type { Option } from './Select.types';
+
 import { assoc, includes } from 'ramda';
-import { StylesConfig } from 'react-select';
 
 import { pxToRem } from '../../../../utils';
 import { theme } from '../../../../theme';
-import { Option } from './Select.types';
 
 const stateStyles = {
   padding: `${pxToRem(0, 15)}`,

--- a/src/components/Filters/components/SingleDatePicker/SingleDatePicker.stories.tsx
+++ b/src/components/Filters/components/SingleDatePicker/SingleDatePicker.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/Filters/components/TagsInput/Tag.tsx
+++ b/src/components/Filters/components/TagsInput/Tag.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { TagsProps } from './Tag.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -14,7 +16,6 @@ import {
   getRadii,
   pxToRem,
 } from '../../../../utils';
-import { TagsProps } from './Tag.types';
 
 const Container = styled(Padbox)`
   display: flex;
@@ -38,7 +39,7 @@ const RemoveButton = styled.button`
   font-size: ${pxToRem(10)};
 `;
 
-const Tag: React.FC<TagsProps> = ({ value, onClose }) => (
+const Tag: FC<TagsProps> = ({ value, onClose }) => (
   <Container alignItems="center">
     {value}{' '}
     <RemoveButton type="button" onClick={onClose}>

--- a/src/components/Filters/components/TagsInput/Tag.types.ts
+++ b/src/components/Filters/components/TagsInput/Tag.types.ts
@@ -1,4 +1,6 @@
+import type { MouseEventHandler } from 'react';
+
 export interface TagsProps {
   value: string;
-  onClose: React.MouseEventHandler<HTMLButtonElement>;
+  onClose: MouseEventHandler<HTMLButtonElement>;
 }

--- a/src/components/Filters/components/TagsInput/TagsInput.stories.tsx
+++ b/src/components/Filters/components/TagsInput/TagsInput.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 

--- a/src/components/Filters/components/TagsInput/TagsInput.tsx
+++ b/src/components/Filters/components/TagsInput/TagsInput.tsx
@@ -1,4 +1,7 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import type { TagsContainerProps, TagsInputProps } from './TagsInput.types';
+
+import { useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import {
@@ -25,7 +28,6 @@ import {
   pxToRem,
 } from '../../../../utils';
 import { validatePattern } from '../../helpers';
-import { TagsContainerProps, TagsInputProps } from './TagsInput.types';
 
 const Container = styled(Padbox)<TagsContainerProps>`
   display: flex;
@@ -89,7 +91,7 @@ const InputContainer = styled.div`
 const doesValueAlreadyExist = (tags, valueArray) =>
   any(includes(__, tags))(valueArray);
 
-const TagsInput: React.FC<TagsInputProps> = ({
+const TagsInput: FC<TagsInputProps> = ({
   value: tags = [],
   onChange,
   maxLength,

--- a/src/components/Filters/components/TagsInput/TagsInput.types.ts
+++ b/src/components/Filters/components/TagsInput/TagsInput.types.ts
@@ -1,4 +1,4 @@
-import { PadboxProps } from '../../../layout/Padbox/Padbox';
+import type { PadboxProps } from '../../../layout/Padbox/Padbox';
 
 export interface TagsInputProps {
   value: string[];

--- a/src/components/Filters/hooks/useFilterRow.test.ts
+++ b/src/components/Filters/hooks/useFilterRow.test.ts
@@ -1,6 +1,7 @@
+import type { Field } from '../Filters.types';
+
 import { renderHook } from '@testing-library/react-hooks';
 
-import { Field } from '../Filters.types';
 import { mockTestFields } from '../mocks/options';
 import { useFilterRow } from './useFilterRow';
 

--- a/src/components/Filters/hooks/useFilterRow.ts
+++ b/src/components/Filters/hooks/useFilterRow.ts
@@ -1,9 +1,10 @@
-import { find, map, pick, pipe, prop, propEq } from 'ramda';
-import { isUndefined } from 'ramda-adjunct';
+import type { Condition, Field } from '../Filters.types';
+import type { PickOption, UseFilterRowType } from './useFilterRow.types';
+import type { Option } from '../components/Select/Select.types';
 
-import { Condition, Field } from '../Filters.types';
-import { PickOption, UseFilterRowType } from './useFilterRow.types';
-import { Option } from '../components/Select/Select.types';
+import { isUndefined } from 'ramda-adjunct';
+import { find, map, pick, pipe, prop, propEq } from 'ramda';
+
 import { useLogger } from '../../../hooks/useLogger';
 
 export const normalizeOptions: <O extends Option>(options: O) => PickOption<O> =

--- a/src/components/Filters/hooks/useFilterRow.types.ts
+++ b/src/components/Filters/hooks/useFilterRow.types.ts
@@ -1,7 +1,6 @@
-import React from 'react';
-
-import { Condition, Field } from '../Filters.types';
-import { Option } from '../components/Select/Select.types';
+import type { ReactNode } from 'react';
+import type { Condition, Field } from '../Filters.types';
+import type { Option } from '../components/Select/Select.types';
 
 export type PickOption<O extends Option> = Pick<O, 'value' | 'label'>;
 
@@ -9,5 +8,5 @@ export interface UseFilterRowType {
   field: PickOption<Field>;
   conditions: PickOption<Condition>[];
   condition: PickOption<Condition>;
-  component: React.ReactNode;
+  component: ReactNode;
 }

--- a/src/components/Filters/hooks/useStateButton.ts
+++ b/src/components/Filters/hooks/useStateButton.ts
@@ -1,8 +1,9 @@
+import type { IconProps, StateButtonIconHook } from './useStateButton.types';
+
 import { useEffect, useState } from 'react';
 
 import { SSCIconNames } from '../../../theme/icons/icons.enums';
 import { ColorTypes } from '../../../theme/colors.enums';
-import { IconProps, StateButtonIconHook } from './useStateButton.types';
 
 const timesIconColor = ColorTypes.neutral700;
 const checkIconColor = ColorTypes.neutral600;

--- a/src/components/Filters/hooks/useStateButton.types.ts
+++ b/src/components/Filters/hooks/useStateButton.types.ts
@@ -1,4 +1,4 @@
-import { Color } from '../../../theme/colors.types';
+import type { Color } from '../../../theme/colors.types';
 
 export interface IconProps {
   iconName: string;

--- a/src/components/Filters/mocks/options.ts
+++ b/src/components/Filters/mocks/options.ts
@@ -1,3 +1,5 @@
+import type { Field, Filter } from '../Filters.types';
+
 import {
   CountFilter,
   DateRangePickerFilter,
@@ -8,7 +10,6 @@ import {
   SingleDatePickerFilter,
   TagsInputFilter,
 } from '../components';
-import { Field, Filter } from '../Filters.types';
 import { Operators } from '../Filters.enums';
 import { patterns, validateDomains, validateIPs } from './validations';
 

--- a/src/components/FlexContainer/FlexContainer.stories.tsx
+++ b/src/components/FlexContainer/FlexContainer.stories.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 
 import { H2, Paragraph } from '../typographyLegacy';
 import FlexContainer from './FlexContainer';

--- a/src/components/FlexContainer/FlexContainer.tsx
+++ b/src/components/FlexContainer/FlexContainer.tsx
@@ -1,9 +1,10 @@
+import type { FlexContainerProps } from './FlexContainer.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { prop } from 'ramda';
 
 import { createSpacings } from '../../utils';
-import { FlexContainerProps } from './FlexContainer.types';
 
 const FlexContainer = styled.div<FlexContainerProps>`
   display: flex;

--- a/src/components/FlexContainer/FlexContainer.types.ts
+++ b/src/components/FlexContainer/FlexContainer.types.ts
@@ -1,6 +1,5 @@
-import { Property } from 'csstype';
-
-import { SpacingProps } from '../../types/spacing.types';
+import type { Property } from 'csstype';
+import type { SpacingProps } from '../../types/spacing.types';
 
 export interface FlexContainerProps extends SpacingProps {
   alignItems?: Property.AlignItems;

--- a/src/components/FullscreenModal/Footer/Footer.tsx
+++ b/src/components/FullscreenModal/Footer/Footer.tsx
@@ -1,4 +1,7 @@
-import React, { useRef } from 'react';
+import type { FC } from 'react';
+import type { FooterProps } from './Footer.types';
+
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -6,7 +9,6 @@ import { getColor, pxToRem } from '../../../utils';
 import { ScrollToTopButton } from '../ScrollToTopButton';
 import { useStickyFooter } from '../hooks/useStickyFooter';
 import { Col, Container, Inline, Padbox, Row } from '../../layout';
-import { FooterProps } from './Footer.types';
 import { SpaceSizes } from '../../../theme';
 
 const BaseStickyFooter = styled.footer`
@@ -24,7 +26,7 @@ const BaseFooter = styled.footer`
   margin-top: ${pxToRem(40)};
 `;
 
-const Footer: React.FC<FooterProps> = ({
+const Footer: FC<FooterProps> = ({
   children,
   width,
   offset,

--- a/src/components/FullscreenModal/Footer/Footer.types.ts
+++ b/src/components/FullscreenModal/Footer/Footer.types.ts
@@ -1,6 +1,8 @@
+import type { MutableRefObject } from 'react';
+
 export interface FooterProps {
   width: number;
   offset: number;
-  modalRef: React.MutableRefObject<HTMLElement>;
+  modalRef: MutableRefObject<HTMLElement>;
   scrollToTopButtonLabel: string;
 }

--- a/src/components/FullscreenModal/FullscreenModal.stories.tsx
+++ b/src/components/FullscreenModal/FullscreenModal.stories.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect, useRef } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { FC } from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
+import { useCallback, useEffect, useRef } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { Inline } from '../layout';
@@ -72,7 +74,7 @@ function Footer() {
     </Inline>
   );
 }
-const Sidebar: React.FC<{
+const Sidebar: FC<{
   modalRef?: HTMLElement;
 }> = ({ modalRef }) => {
   useEffect(() => {
@@ -130,22 +132,22 @@ SingleColumn6.argTypes = {
   header: {
     control: { disable: true },
     description: 'Content of the header wrapper',
-    table: { type: { summary: 'React.node' } },
+    table: { type: { summary: ' node' } },
   },
   content: {
     control: { disable: true },
     description: 'Content of the content wrapper',
-    table: { type: { summary: 'React.node' } },
+    table: { type: { summary: ' node' } },
   },
   footer: {
     control: { disable: true },
     description: 'Content of the footer wrapper',
-    table: { type: { summary: 'React.node' } },
+    table: { type: { summary: ' node' } },
   },
   sidebar: {
     control: { disable: true },
     description: 'Content of the sidebar wrapper',
-    table: { type: { summary: 'React.node' } },
+    table: { type: { summary: ' node' } },
   },
   scrollToTopButtonLabel: {
     control: { disable: true },

--- a/src/components/FullscreenModal/FullscreenModal.tsx
+++ b/src/components/FullscreenModal/FullscreenModal.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, useCallback, useEffect, useRef } from 'react';
+import type { MutableRefObject, ReactElement } from 'react';
+import type {
+  ColumnConfigMap,
+  FullscreenModalProps,
+} from './FullscreenModal.types';
+
+import { forwardRef, useCallback, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { isUndefined, noop } from 'ramda-adjunct';
@@ -7,7 +13,6 @@ import { getColor } from '../../utils';
 import ModalHeader from './Header/Header';
 import ModalFooter from './Footer/Footer';
 import { FullscreenModalLayouts } from './FullscreenModal.enums';
-import { ColumnConfigMap, FullscreenModalProps } from './FullscreenModal.types';
 import { Col, Container, Row } from '../layout';
 import { useModal } from './hooks/useModal';
 import { useLogger } from '../../hooks/useLogger';
@@ -61,8 +66,8 @@ const FullscreenModalContent = forwardRef(
       scrollToTopButtonLabel,
       onClose = noop,
     }: FullscreenModalProps,
-    ref: React.MutableRefObject<HTMLDivElement>,
-  ): React.ReactElement => {
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const { error } = useLogger('FullscreenModal');
     const closeOnEsc = useCallback(
       (e: KeyboardEvent) => {
@@ -141,8 +146,8 @@ You should either provide content in "sidebar" property or switch layout to "${F
 const FullscreenModal = forwardRef(
   (
     props: FullscreenModalProps,
-    ref: React.MutableRefObject<HTMLDivElement>,
-  ): React.ReactElement => {
+    ref: MutableRefObject<HTMLDivElement>,
+  ): ReactElement => {
     const defaultModalRef = useRef<HTMLDivElement>();
     const resolvedModalRef = ref || defaultModalRef;
     const renderModal = useModal(

--- a/src/components/FullscreenModal/FullscreenModal.types.ts
+++ b/src/components/FullscreenModal/FullscreenModal.types.ts
@@ -1,4 +1,5 @@
-import {
+import type { ReactNode } from 'react';
+import type {
   FullscreenModalLayouts,
   FullscreenModalSizes,
 } from './FullscreenModal.enums';
@@ -14,10 +15,10 @@ export type ColumnConfig = Record<
 export type ColumnConfigMap = Record<Layouts, ColumnConfig>;
 export interface FullscreenModalProps {
   layout: Layouts;
-  header: React.ReactNode;
-  content: React.ReactNode;
-  footer: React.ReactNode;
-  sidebar?: React.ReactNode;
+  header: ReactNode;
+  content: ReactNode;
+  footer: ReactNode;
+  sidebar?: ReactNode;
   scrollToTopButtonLabel?: string;
   onClose: () => void;
 }

--- a/src/components/FullscreenModal/Header/Header.tsx
+++ b/src/components/FullscreenModal/Header/Header.tsx
@@ -1,4 +1,7 @@
-import React, { useRef } from 'react';
+import type { FC } from 'react';
+import type { HeaderProps } from './Header.types';
+
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -6,7 +9,6 @@ import { getColor, pxToRem } from '../../../utils';
 import { Col, Container, Inline, Row } from '../../layout';
 import { H2, H3 } from '../../typographyLegacy';
 import { useStickyHeader } from '../hooks/useStickyHeader';
-import { HeaderProps } from './Header.types';
 import { CloseButton } from '../../CloseButton';
 
 const BaseStickyHeader = styled.header`
@@ -23,7 +25,7 @@ const BaseHeader = styled.header`
   padding: ${pxToRem(56, 0, 24)};
 `;
 
-const Header: React.FC<HeaderProps> = ({
+const Header: FC<HeaderProps> = ({
   children,
   width,
   offset,

--- a/src/components/FullscreenModal/Header/Header.types.ts
+++ b/src/components/FullscreenModal/Header/Header.types.ts
@@ -1,6 +1,8 @@
+import type { MutableRefObject } from 'react';
+
 export interface HeaderProps {
   width: number;
   offset: number;
-  modalRef: React.MutableRefObject<HTMLElement>;
+  modalRef: MutableRefObject<HTMLElement>;
   handleClose: () => void;
 }

--- a/src/components/FullscreenModal/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/src/components/FullscreenModal/ScrollToTopButton/ScrollToTopButton.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { ScrollToTopButtonProps } from './ScrollToTopButton.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { isNotUndefined } from 'ramda-adjunct';
@@ -8,7 +10,6 @@ import { Button } from '../../Button';
 import { ButtonColors, ButtonVariants } from '../../Button/Button.enums';
 import { Icon } from '../../Icon';
 import { SSCIconNames } from '../../../theme/icons/icons.enums';
-import { ScrollToTopButtonProps } from './ScrollToTopButton.types';
 
 const StyledButton = styled(Button)`
   flex-direction: column;
@@ -23,7 +24,7 @@ const ButtonText = styled.span`
   margin-top: ${pxToRem(4)};
 `;
 
-const ScrollToTopButton: React.FC<ScrollToTopButtonProps> = ({
+const ScrollToTopButton: FC<ScrollToTopButtonProps> = ({
   onClick,
   label = 'Scroll to top',
 }) => {

--- a/src/components/FullscreenModal/hooks/useModal.test.tsx
+++ b/src/components/FullscreenModal/hooks/useModal.test.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import type { FC } from 'react';
+
 import { renderHook } from '@testing-library/react-hooks';
 
 import { useModal } from './useModal';
 import { defaultDSContext } from '../../../theme/DSProvider/DSProvider';
 
-const Modal: React.FC = () => <div>Modal Content</div>;
+const Modal: FC = () => <div>Modal Content</div>;
 
 describe('useModal', () => {
   it('should append inline styles to portals container when mounted', () => {

--- a/src/components/FullscreenModal/hooks/useModal.ts
+++ b/src/components/FullscreenModal/hooks/useModal.ts
@@ -1,4 +1,6 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import type { ReactElement, ReactPortal } from 'react';
+
+import { useContext, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { isNull } from 'ramda-adjunct';
 
@@ -15,7 +17,7 @@ const createEl = (id: string): HTMLElement => {
 const getContainer = (id: string): HTMLElement =>
   document.getElementById(id) || createEl(id);
 
-export const useModal = (el: React.ReactElement): (() => React.ReactPortal) => {
+export const useModal = (el: ReactElement): (() => ReactPortal) => {
   const { portalsContainerId } = useContext(DSContext);
   const containerRef = useRef(getContainer(portalsContainerId));
 

--- a/src/components/FullscreenModal/hooks/useStickyFooter.ts
+++ b/src/components/FullscreenModal/hooks/useStickyFooter.ts
@@ -1,3 +1,5 @@
+import type { MutableRefObject } from 'react';
+
 import { useCallback, useEffect, useState } from 'react';
 import { isNull } from 'ramda-adjunct';
 
@@ -5,8 +7,8 @@ import { useStickyObserver } from './useStickyObserver';
 import { useDebouncedHandler } from './useDebouncedHandler';
 
 export const useStickyFooter = (
-  modalRef: React.MutableRefObject<HTMLElement>,
-  modalFooterRef: React.MutableRefObject<HTMLElement>,
+  modalRef: MutableRefObject<HTMLElement>,
+  modalFooterRef: MutableRefObject<HTMLElement>,
 ): { isFixed: boolean; shouldShowScrollToTopButton: boolean } => {
   const [isFixed, setIsFixed] = useState(false);
   const [shouldShowScrollToTopButton, setShouldShowScrollToTopButton] =

--- a/src/components/FullscreenModal/hooks/useStickyHeader.ts
+++ b/src/components/FullscreenModal/hooks/useStickyHeader.ts
@@ -1,3 +1,5 @@
+import type { MutableRefObject } from 'react';
+
 import { useCallback, useState } from 'react';
 import { isNull } from 'ramda-adjunct';
 
@@ -5,8 +7,8 @@ import { useStickyObserver } from './useStickyObserver';
 import { useDebouncedHandler } from './useDebouncedHandler';
 
 export const useStickyHeader = (
-  modalRef: React.MutableRefObject<HTMLElement>,
-  modalHeaderRef: React.MutableRefObject<HTMLElement>,
+  modalRef: MutableRefObject<HTMLElement>,
+  modalHeaderRef: MutableRefObject<HTMLElement>,
 ): { isFixed: boolean } => {
   const [isFixed, setIsFixed] = useState(false);
 

--- a/src/components/FullscreenModal/hooks/useStickyObserver.ts
+++ b/src/components/FullscreenModal/hooks/useStickyObserver.ts
@@ -1,9 +1,11 @@
+import type { MutableRefObject } from 'react';
+
 import { useEffect, useRef } from 'react';
 import { isNotNull } from 'ramda-adjunct';
 
 export const useStickyObserver = (
-  modalRef: React.MutableRefObject<HTMLElement>,
-  elementRef: React.MutableRefObject<HTMLElement>,
+  modalRef: MutableRefObject<HTMLElement>,
+  elementRef: MutableRefObject<HTMLElement>,
   isInView: () => void,
 ): void => {
   const observerRef = useRef(null);

--- a/src/components/HexGrade/HexGrade.stories.tsx
+++ b/src/components/HexGrade/HexGrade.stories.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { HexGradeProps } from './HexGrade.types';
 
-import { HexGradeProps } from './HexGrade.types';
 import { HexGradeGrades, HexGradeVariants } from './HexGrade.enums';
 import HexGrade from './HexGrade';
 import { generateControl } from '../../utils/tests/storybook';

--- a/src/components/HexGrade/HexGrade.tsx
+++ b/src/components/HexGrade/HexGrade.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { HexGradeProps } from './HexGrade.types';
+
 import PropTypes from 'prop-types';
 import { defaultTo, path, pipe } from 'ramda';
 import { isNotUndefined } from 'ramda-adjunct';
@@ -9,7 +11,6 @@ import { colors } from '../../theme/colors';
 import { SpacingSizeValuePropType } from '../../types/spacing.types';
 import { createMarginSpacing } from '../../utils';
 import { HexGradeGrades, HexGradeVariants } from './HexGrade.enums';
-import { HexGradeProps } from './HexGrade.types';
 import { CLX_COMPONENT } from '../../theme/constants';
 
 const grades = {
@@ -54,7 +55,7 @@ const StyledSVG = styled.svg<HexGradeProps>`
   ${({ margin }) => createMarginSpacing(margin)};
 `;
 
-const HexGrade: React.FC<HexGradeProps> = ({
+const HexGrade: FC<HexGradeProps> = ({
   variant = HexGradeVariants.solid,
   grade,
   size = 64,

--- a/src/components/HexGrade/HexGrade.types.ts
+++ b/src/components/HexGrade/HexGrade.types.ts
@@ -1,5 +1,5 @@
-import { SpacingSizeValue } from '../../types/spacing.types';
-import { HexGradeGrades, HexGradeVariants } from './HexGrade.enums';
+import type { SpacingSizeValue } from '../../types/spacing.types';
+import type { HexGradeGrades, HexGradeVariants } from './HexGrade.enums';
 
 export type Variants = typeof HexGradeVariants[keyof typeof HexGradeVariants];
 export type Grades = typeof HexGradeGrades[keyof typeof HexGradeGrades];

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { IconProps } from './Icon.types';
+
 import styled from 'styled-components';
-import { Meta, Story } from '@storybook/react/types-6-0';
 import { head, pipe, sortBy, toPairs } from 'ramda';
 
 import Icon from './Icon';
-import { IconProps } from './Icon.types';
 import { IconTypes, SSCIconNames } from '../../theme/icons/icons.enums';
 import { generateControl } from '../../utils/tests/storybook';
 import { Text } from '../typographyLegacy';

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,15 +1,13 @@
-import React from 'react';
+import type { FontAwesomeIconProps } from '@fortawesome/react-fontawesome';
+import type { IconName, IconPrefix } from '@fortawesome/fontawesome-svg-core';
+import type { FC } from 'react';
+import type { Color } from '../../theme/colors.types';
+import type { IconProps, SSCIcons, Types } from './Icon.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import {
-  FontAwesomeIcon,
-  FontAwesomeIconProps,
-} from '@fortawesome/react-fontawesome';
-import {
-  IconName,
-  IconPrefix,
-  findIconDefinition,
-} from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { findIconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { includes } from 'ramda';
 import { isNotUndefined } from 'ramda-adjunct';
 import cls from 'classnames';
@@ -17,8 +15,6 @@ import cls from 'classnames';
 import { createSpacings, getColor } from '../../utils';
 import { IconTypes, SSCIconNames } from '../../theme/icons/icons.enums';
 import { ColorTypes } from '../../theme/colors.enums';
-import { Color } from '../../theme/colors.types';
-import { IconProps, SSCIcons, Types } from './Icon.types';
 import { SpacingSizeValuePropType } from '../../types/spacing.types';
 import { CLX_COMPONENT } from '../../theme/constants';
 
@@ -30,7 +26,7 @@ const StyledIcon = styled(FontAwesomeIcon).withConfig<{ color: Color }>({
   ${createSpacings};
 `;
 
-const Icon: React.FC<
+const Icon: FC<
   IconProps &
     Omit<FontAwesomeIconProps, 'icon' | 'fixedWidth' | 'color' | 'size'>
 > = ({

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -1,6 +1,6 @@
-import { Color } from '../../theme/colors.types';
-import { IconTypes, SSCIconNames } from '../../theme/icons/icons.enums';
-import { SpacingProps } from '../../types/spacing.types';
+import type { Color } from '../../theme/colors.types';
+import type { IconTypes, SSCIconNames } from '../../theme/icons/icons.enums';
+import type { SpacingProps } from '../../types/spacing.types';
 
 export type SSCIcons = typeof SSCIconNames[keyof typeof SSCIconNames];
 export type Types = typeof IconTypes[keyof typeof IconTypes];

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ModalProps } from './Modal.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import Modal from './Modal';
-import { ModalProps } from './Modal.types';
 import { ModalSizes } from './Modal.enums';
 import { H5, Paragraph } from '../typographyLegacy';
 import { Inline, Padbox } from '../layout';

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,11 +1,12 @@
-import React, { forwardRef, useContext } from 'react';
+import type { ModalProps } from './Modal.types';
+
+import { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import usePortal from 'react-cool-portal';
 import styled from 'styled-components';
 import { isNotUndefined } from 'ramda-adjunct';
 import cls from 'classnames';
 
-import { ModalProps } from './Modal.types';
 import { ModalSizes } from './Modal.enums';
 import { useLockBodyScroll } from '../../hooks/useLockBodyScroll';
 import { useOuterClick } from '../../hooks/useOuterCallback';

--- a/src/components/Modal/Modal.types.ts
+++ b/src/components/Modal/Modal.types.ts
@@ -1,13 +1,12 @@
-import React from 'react';
-
-import { ModalSizes } from './Modal.enums';
+import type { MouseEventHandler, ReactNode } from 'react';
+import type { ModalSizes } from './Modal.enums';
 
 export type Sizes = typeof ModalSizes[keyof typeof ModalSizes];
 
 export interface ModalProps {
-  children: React.ReactNode;
-  onClose?: React.MouseEventHandler;
-  footer?: React.ReactNode;
+  children: ReactNode;
+  onClose?: MouseEventHandler;
+  footer?: ReactNode;
   title?: string;
   size?: Sizes;
   className?: string;

--- a/src/components/Nav/Nav.stories.tsx
+++ b/src/components/Nav/Nav.stories.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { NavItemProps } from './NavItem.types';
+
 import { action } from '@storybook/addon-actions';
-import { Meta, Story } from '@storybook/react/types-6-0';
 import { BrowserRouter } from 'react-router-dom';
 
 import { Badges } from '../../../.storybook/storybook.enums';
 import Nav from './Nav';
 import NavItem from './NavItem';
-import { NavItemProps } from './NavItem.types';
 
 export default {
   title: 'components/Nav',

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { InlineProps } from '../layout/Inline/Inline';
 
 import { useLogger } from '../../hooks/useLogger';
 import { Inline } from '../layout';
-import { InlineProps } from '../layout/Inline/Inline';
 
-const Nav: React.FC<InlineProps> = (props) => {
+const Nav: FC<InlineProps> = (props) => {
   const { warn } = useLogger('Nav');
   warn(`<Nav> and <NavItem> components are deprecated and will be removed soon.
 

--- a/src/components/Nav/NavItem.tsx
+++ b/src/components/Nav/NavItem.tsx
@@ -1,3 +1,5 @@
+import type { NavItemProps } from './NavItem.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
@@ -8,7 +10,6 @@ import {
   getLineHeight,
   pxToRem,
 } from '../../utils';
-import { NavItemProps } from './NavItem.types';
 import { BaseButton } from '../_internal/BaseButton';
 import { BaseButtonVariants } from '../_internal/BaseButton/BaseButton.enums';
 

--- a/src/components/Nav/NavItem.types.ts
+++ b/src/components/Nav/NavItem.types.ts
@@ -1,4 +1,4 @@
-import { ButtonProps } from '../Button/Button.types';
+import type { ButtonProps } from '../Button/Button.types';
 
 export interface NavItemProps extends ButtonProps {
   isActive?: boolean;

--- a/src/components/Pagination/PageButtons.test.tsx
+++ b/src/components/Pagination/PageButtons.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/Pagination/PageButtons.tsx
+++ b/src/components/Pagination/PageButtons.tsx
@@ -1,9 +1,11 @@
-import React, { useMemo } from 'react';
+import type { FC } from 'react';
+import type { PageButtonsProps } from './Pagination.types';
+
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { unfold } from 'ramda';
 
 import { PaginationItem, PaginationItemElipsis } from './PaginationItem';
-import { PageButtonsProps } from './Pagination.types';
 
 const generatePages = (start: number, end: number): number[] =>
   unfold((p) => (p > end ? false : [p, p + 1]), start);
@@ -54,7 +56,7 @@ export const calculatePagePositions: (
 const formatNumber = (val: number) =>
   new Intl.NumberFormat('en-US').format(val);
 
-const PageButtons: React.FC<PageButtonsProps> = ({
+const PageButtons: FC<PageButtonsProps> = ({
   currentPage,
   pageCount,
   onChange,

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { PaginationProps } from './Pagination.types';
+
 import { action } from '@storybook/addon-actions';
 
 import Pagination from './Pagination';
-import { PaginationProps } from './Pagination.types';
 import { Button } from '..';
 
 export default {

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { renderWithProviders } from '../../utils/tests/renderWithProviders';

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { PaginationProps } from './Pagination.types';
+
 import PropTypes from 'prop-types';
 
 import { SSCIconNames } from '../../theme/icons/icons.enums';
@@ -6,11 +8,10 @@ import { Icon } from '../Icon';
 import { PaginationItem } from './PaginationItem';
 import PageButtons from './PageButtons';
 import { Inline } from '../layout';
-import { PaginationProps } from './Pagination.types';
 import { SpaceSizes } from '../../theme';
 import { CLX_COMPONENT } from '../../theme/constants';
 
-const Pagination: React.FC<PaginationProps> = ({
+const Pagination: FC<PaginationProps> = ({
   pageCount,
   currentPage,
   onPageChange,

--- a/src/components/Pagination/Pagination.types.ts
+++ b/src/components/Pagination/Pagination.types.ts
@@ -1,9 +1,9 @@
-import { ReactNode } from 'react';
+import type { HTMLProps, ReactNode } from 'react';
 
 export type OnPageChangeFn = (page: number) => void;
 
 export type customRenderItem = (
-  props: PaginationItemProps & React.HTMLProps<HTMLButtonElement>,
+  props: PaginationItemProps & HTMLProps<HTMLButtonElement>,
 ) => ReactNode;
 export interface PageButtonsProps {
   currentPage: number;

--- a/src/components/Pagination/PaginationItem.test.tsx
+++ b/src/components/Pagination/PaginationItem.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/Pagination/PaginationItem.tsx
+++ b/src/components/Pagination/PaginationItem.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { PaginationItemProps } from './Pagination.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
@@ -11,7 +13,6 @@ import {
   pxToRem,
 } from '../../utils';
 import { Padbox } from '../layout';
-import { PaginationItemProps } from './Pagination.types';
 
 const StyledPaginationComponent = styled.button<{
   $isShrinked: boolean;
@@ -70,7 +71,7 @@ const StyledPaginationComponent = styled.button<{
         `};
 `;
 
-export const PaginationItem: React.FC<PaginationItemProps> = ({
+export const PaginationItem: FC<PaginationItemProps> = ({
   children,
   isDisabled,
   isCurrent,

--- a/src/components/Pill/Pill.stories.tsx
+++ b/src/components/Pill/Pill.stories.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { PillProps } from './Pill.types';
+
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
 
@@ -8,7 +9,6 @@ import { Cluster, Inline, Stack } from '../layout';
 import { H4 } from '../typographyLegacy';
 import { Icon } from '../Icon';
 import Pill from './Pill';
-import { PillProps } from './Pill.types';
 import { PillSizes, PillVariants } from './Pill.enums';
 import { getRadii } from '../../utils';
 import { RadiusTypes } from '../../theme/radii.enums';

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -1,17 +1,25 @@
-import React from 'react';
+import type {
+  EventHandler,
+  FC,
+  KeyboardEvent,
+  KeyboardEventHandler,
+  MouseEvent,
+  MouseEventHandler,
+} from 'react';
+import type { PillProps } from './Pill.types';
+
 import { gt } from 'ramda';
 import { isNotUndefined } from 'ramda-adjunct';
 import PropTypes from 'prop-types';
 import cls from 'classnames';
 
 import { PillSizes, PillVariants } from './Pill.enums';
-import { PillProps } from './Pill.types';
 import PillWrapper from './PillWrapper';
 import PillLabel from './PillLabel';
 import PillRemoveButton from './PillRemoveButton';
 import { CLX_COMPONENT } from '../../theme/constants';
 
-const Pill: React.FC<PillProps> = ({
+const Pill: FC<PillProps> = ({
   label,
   variant = PillVariants.solid,
   size = PillSizes.sm,
@@ -26,14 +34,12 @@ const Pill: React.FC<PillProps> = ({
   const isPillClickable = isNotUndefined(onClick) || isClickable;
   const isPillRemovable = isNotUndefined(onRemove);
 
-  const handleOnClick: React.EventHandler<
-    React.MouseEvent | React.KeyboardEvent
-  > = (e) => {
+  const handleOnClick: EventHandler<MouseEvent | KeyboardEvent> = (e) => {
     if (isNotUndefined(onClick)) {
       onClick(e);
     }
   };
-  const handleOnKeyDown: React.KeyboardEventHandler<HTMLElement> = (e) => {
+  const handleOnKeyDown: KeyboardEventHandler<HTMLElement> = (e) => {
     switch (e.key) {
       case ' ':
       case 'Enter':
@@ -43,11 +49,11 @@ const Pill: React.FC<PillProps> = ({
     }
   };
 
-  const handleOnRemove: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+  const handleOnRemove: MouseEventHandler<HTMLButtonElement> = (e) => {
     e.stopPropagation();
     onRemove(e);
   };
-  const handleRemoveOnKeyDown: React.KeyboardEventHandler<HTMLButtonElement> = (
+  const handleRemoveOnKeyDown: KeyboardEventHandler<HTMLButtonElement> = (
     e,
   ) => {
     switch (e.key) {

--- a/src/components/Pill/Pill.types.ts
+++ b/src/components/Pill/Pill.types.ts
@@ -1,4 +1,12 @@
-import { PillSizes, PillVariants } from './Pill.enums';
+import type {
+  ElementType,
+  EventHandler,
+  HTMLAttributes,
+  KeyboardEvent,
+  MouseEvent,
+  ReactNode,
+} from 'react';
+import type { PillSizes, PillVariants } from './Pill.enums';
 
 export type Variants = typeof PillVariants[keyof typeof PillVariants];
 export type Sizes = typeof PillSizes[keyof typeof PillSizes];
@@ -8,7 +16,7 @@ export interface StyledPillWrapperProps {
   $isClickable: boolean;
 }
 
-export interface PillWrapperProps extends React.HTMLAttributes<HTMLElement> {
+export interface PillWrapperProps extends HTMLAttributes<HTMLElement> {
   /**
    * Styling variant of the pill
    */
@@ -28,8 +36,8 @@ export interface PillWrapperProps extends React.HTMLAttributes<HTMLElement> {
    * property is passed in, this can be overriden by `isClickable` property when using
    * custom element such as `a` tag without `onClick` property.
    */
-  onClick?: React.EventHandler<React.MouseEvent | React.KeyboardEvent>;
-  as?: React.ElementType;
+  onClick?: EventHandler<MouseEvent | KeyboardEvent>;
+  as?: ElementType;
 }
 
 export interface PillLabelProps {
@@ -38,7 +46,7 @@ export interface PillLabelProps {
 }
 
 export interface PillRemoveButtonProps
-  extends React.HTMLAttributes<HTMLButtonElement> {
+  extends HTMLAttributes<HTMLButtonElement> {
   pillLabel: string;
 }
 
@@ -51,7 +59,7 @@ export interface PillProps extends Partial<PillWrapperProps> {
    * Callback called when remove button is clicked. Remove button is rendered
    * only when this property is defined.
    */
-  onRemove?: React.EventHandler<React.MouseEvent | React.KeyboardEvent>;
+  onRemove?: EventHandler<MouseEvent | KeyboardEvent>;
   /**
    * Maximal number of characters to display without truncation. If label is longer
    * that the limit it will be truncated with the ellipsis. Pass `0` to disable truncation.
@@ -60,6 +68,6 @@ export interface PillProps extends Partial<PillWrapperProps> {
   /**
    * Element rendered before the label.
    */
-  adornment?: React.ReactNode;
+  adornment?: ReactNode;
   className?: string;
 }

--- a/src/components/Pill/PillLabel.ts
+++ b/src/components/Pill/PillLabel.ts
@@ -1,9 +1,10 @@
+import type { PillLabelProps } from './Pill.types';
+
 import styled, { css } from 'styled-components';
 import { gt } from 'ramda';
 
 import { getColor, getFontSize } from '../../utils';
 import { PillSizes } from './Pill.enums';
-import { PillLabelProps } from './Pill.types';
 
 const PillLabelSmall = css`
   font-size: ${getFontSize('md')};

--- a/src/components/Pill/PillRemoveButton.tsx
+++ b/src/components/Pill/PillRemoveButton.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { PillRemoveButtonProps } from './Pill.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 import { getColor, getLineHeight, getRadii, pxToRem } from '../../utils';
 import { SSCIconNames } from '../../theme/icons/icons.enums';
 import { Icon } from '../Icon';
-import { PillRemoveButtonProps } from './Pill.types';
 
 const PillRemoveButtonWrapper = styled.button`
   display: flex;
@@ -29,7 +30,7 @@ const PillRemoveButtonWrapper = styled.button`
   }
 `;
 
-const PillRemoveButton: React.FC<PillRemoveButtonProps> = ({
+const PillRemoveButton: FC<PillRemoveButtonProps> = ({
   pillLabel,
   ...props
 }) => (

--- a/src/components/Pill/PillWrapper.tsx
+++ b/src/components/Pill/PillWrapper.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { PillWrapperProps, StyledPillWrapperProps } from './Pill.types';
+
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 
@@ -7,7 +9,6 @@ import { getColor, getRadii } from '../../utils';
 import { Inline, Padbox } from '../layout';
 import { PaddingTypes } from '../layout/Padbox/Padbox.enums';
 import { PillSizes, PillVariants } from './Pill.enums';
-import { PillWrapperProps, StyledPillWrapperProps } from './Pill.types';
 
 const PillSolid = css`
   background-color: ${getColor('neutral.300')};
@@ -42,7 +43,7 @@ const StyledPillWrapper = styled(Padbox)<StyledPillWrapperProps>`
     `}
 `;
 
-const PillWrapper: React.FC<PillWrapperProps> = ({
+const PillWrapper: FC<PillWrapperProps> = ({
   children,
   variant,
   size,

--- a/src/components/SemanticModal/SemanticModal.stories.tsx
+++ b/src/components/SemanticModal/SemanticModal.stories.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SemanticModalProps } from './SemanticModal.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import SemanticModal from './SemanticModal';
 import { SemanticModalVariants } from './SemanticModal.enums';
-import { SemanticModalProps } from './SemanticModal.types';
 import { Inline, Padbox, Stack } from '../layout';
 import { Button } from '../Button';
 import { ButtonColors } from '../Button/Button.enums';

--- a/src/components/SemanticModal/SemanticModal.tsx
+++ b/src/components/SemanticModal/SemanticModal.tsx
@@ -1,21 +1,26 @@
-import React, { forwardRef } from 'react';
+import type { MouseEvent } from 'react';
+import type {
+  RenderButtonProps,
+  SemanticModalProps,
+} from './SemanticModal.types';
+import type {
+  AbsoluteLinkActionKind,
+  ActionKinds,
+  RelativeLinkActionKind,
+} from '../../types/action.types';
+
+import { forwardRef } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { isNotUndefined } from 'ramda-adjunct';
 
 import { SemanticModalVariants } from './SemanticModal.enums';
-import { RenderButtonProps, SemanticModalProps } from './SemanticModal.types';
 import { Modal, ModalEnums } from '../Modal';
 import { Button, ButtonEnums } from '../Button';
 import { ButtonColors } from '../Button/Button.enums';
 import { Icon } from '../Icon';
 import { H4, Text } from '../typographyLegacy';
-import {
-  AbsoluteLinkActionKind,
-  ActionKinds,
-  ActionKindsPropType,
-  RelativeLinkActionKind,
-} from '../../types/action.types';
+import { ActionKindsPropType } from '../../types/action.types';
 import * as CustomPropTypes from '../../types/customPropTypes';
 import { getColor, pxToRem } from '../../utils';
 import { Center, Inline, Padbox, Stack } from '../layout';
@@ -51,11 +56,11 @@ const renderButton = ({
   <Button
     key={action.name}
     color={color}
-    href={(action as AbsoluteLinkActionKind<[React.MouseEvent]>).href}
+    href={(action as AbsoluteLinkActionKind<[MouseEvent]>).href}
     isLoading={isLoading}
     loadingText={loadingText}
     name={action.name}
-    to={(action as RelativeLinkActionKind<[React.MouseEvent]>).to}
+    to={(action as RelativeLinkActionKind<[MouseEvent]>).to}
     variant={variant}
     onClick={action.onClick}
   >
@@ -92,7 +97,7 @@ const SemanticModal = forwardRef<HTMLDivElement, SemanticModalProps>(
               <Padbox paddingSize={SpaceSizes.md}>
                 <Inline gap={SpaceSizes.md} justify="center">
                   {actions.map(
-                    (action: ActionKinds<[React.MouseEvent]>, index: number) =>
+                    (action: ActionKinds<[MouseEvent]>, index: number) =>
                       isNotUndefined(action) &&
                       renderButton({
                         action,

--- a/src/components/SemanticModal/SemanticModal.types.ts
+++ b/src/components/SemanticModal/SemanticModal.types.ts
@@ -1,21 +1,20 @@
-import React from 'react';
-
-import { SemanticModalVariants } from './SemanticModal.enums';
-import { ButtonColors } from '../Button/Button.enums';
-import { ActionKinds } from '../../types/action.types';
-import { ButtonEnums } from '../Button';
+import type { MouseEvent, MouseEventHandler, ReactNode } from 'react';
+import type { SemanticModalVariants } from './SemanticModal.enums';
+import type { ButtonColors } from '../Button/Button.enums';
+import type { ActionKinds } from '../../types/action.types';
+import type { ButtonEnums } from '../Button';
 
 export type Variants =
   typeof SemanticModalVariants[keyof typeof SemanticModalVariants];
 export type ButtonColors = typeof ButtonColors[keyof typeof ButtonColors];
 
 type ActionsArray = readonly [
-  ActionKinds<[React.MouseEvent]>?,
-  ActionKinds<[React.MouseEvent]>?,
+  ActionKinds<[MouseEvent]>?,
+  ActionKinds<[MouseEvent]>?,
 ];
 
 export interface RenderButtonProps {
-  action: ActionKinds<[React.MouseEvent]>;
+  action: ActionKinds<[MouseEvent]>;
   variant: typeof ButtonEnums.ButtonVariants[keyof typeof ButtonEnums.ButtonVariants];
   color: typeof ButtonEnums.ButtonColors[keyof typeof ButtonEnums.ButtonColors];
   isLoading: boolean;
@@ -24,8 +23,8 @@ export interface RenderButtonProps {
 
 export interface SemanticModalProps {
   title: string;
-  message: React.ReactNode;
-  onClose: React.MouseEventHandler;
+  message: ReactNode;
+  onClose: MouseEventHandler;
   actions: ActionsArray;
   variant?: Variants;
   primaryButtonColor?: ButtonColors;

--- a/src/components/Signal/Signal.stories.tsx
+++ b/src/components/Signal/Signal.stories.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SignalProps } from './Signal.types';
 
-import { SignalProps } from './Signal.types';
 import { SignalKinds } from './Signal.enums';
 import Signal from './Signal';
 import { generateControl } from '../../utils/tests/storybook';

--- a/src/components/Signal/Signal.tsx
+++ b/src/components/Signal/Signal.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { SignalProps } from './Signal.types';
+
 import PropTypes from 'prop-types';
 import { prop } from 'ramda';
 import { isNilOrEmpty } from 'ramda-adjunct';
 import cls from 'classnames';
 
 import { colors } from '../../theme/colors';
-import { SignalProps } from './Signal.types';
 import { SignalKinds } from './Signal.enums';
 import { CLX_COMPONENT } from '../../theme/constants';
 
@@ -59,7 +60,7 @@ const kinds = {
   },
 };
 
-const Signal: React.FC<SignalProps> = ({
+const Signal: FC<SignalProps> = ({
   kind,
   size = 16,
   title = '',

--- a/src/components/Signal/Signal.types.ts
+++ b/src/components/Signal/Signal.types.ts
@@ -1,4 +1,4 @@
-import { SignalKinds } from './Signal.enums';
+import type { SignalKinds } from './Signal.enums';
 
 export type Kinds = typeof SignalKinds[keyof typeof SignalKinds];
 

--- a/src/components/SingleDatePicker/SingleDatePicker.stories.tsx
+++ b/src/components/SingleDatePicker/SingleDatePicker.stories.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SingleDatePickerProps } from '../_internal/BaseSingleDatePicker/SingleDatePicker.types';
+
+import { useState } from 'react';
 
 import SingleDatePicker from './SingleDatePicker';
-import { SingleDatePickerProps } from '../_internal/BaseSingleDatePicker/SingleDatePicker.types';
 
 export default {
   title: 'components/SingleDatePicker',

--- a/src/components/SingleDatePicker/SingleDatePicker.test.tsx
+++ b/src/components/SingleDatePicker/SingleDatePicker.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/SortableList/SortableItem.tsx
+++ b/src/components/SortableList/SortableItem.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { SortableItemProps } from './SortableList.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useSortable } from '@dnd-kit/sortable';
@@ -7,7 +9,6 @@ import { CSS } from '@dnd-kit/utilities';
 import { getColor, getRadii, getSpace, pxToRem } from '../../utils';
 import { Text } from '../typographyLegacy';
 import { TextSizes } from '../typographyLegacy/Text/Text.enums';
-import { SortableItemProps } from './SortableList.types';
 import { SpaceSizes } from '../../theme';
 import { Inline, Padbox } from '../layout';
 
@@ -41,11 +42,7 @@ const Handle = styled(Padbox)`
   }
 `;
 
-const SortableItem: React.FC<SortableItemProps> = ({
-  label,
-  id,
-  renderItem,
-}) => {
+const SortableItem: FC<SortableItemProps> = ({ label, id, renderItem }) => {
   const {
     attributes,
     listeners,

--- a/src/components/SortableList/SortableList.stories.tsx
+++ b/src/components/SortableList/SortableList.stories.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SortableListProps } from './SortableList.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { zipObj } from 'ramda';
 
 import SortableList from './SortableList';
-import { SortableListProps } from './SortableList.types';
 
 export default {
   title: 'components/SortableList',

--- a/src/components/SortableList/SortableList.tsx
+++ b/src/components/SortableList/SortableList.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { SortableListProps } from './SortableList.types';
+
 import PropTypes from 'prop-types';
 import {
   DndContext,
@@ -22,7 +24,6 @@ import styled from 'styled-components';
 import { Stack } from '../layout';
 import { SpaceSizes } from '../../theme';
 import SortableItem from './SortableItem';
-import { SortableListProps } from './SortableList.types';
 import { pxToRem } from '../../utils';
 import { CLX_COMPONENT } from '../../theme/constants';
 
@@ -34,7 +35,7 @@ const SortableListRoot = styled.div<{
     isNotUndefined($maxHeight) && pxToRem($maxHeight)};
 `;
 
-const SortableList: React.FC<SortableListProps> = ({
+const SortableList: FC<SortableListProps> = ({
   items,
   labels,
   renderItem,

--- a/src/components/SortableList/SortableList.types.ts
+++ b/src/components/SortableList/SortableList.types.ts
@@ -1,17 +1,17 @@
-import {
+import type {
   DragCancelEvent,
   DragEndEvent,
   DragOverEvent,
   DragStartEvent,
 } from '@dnd-kit/core';
-import React from 'react';
+import type { ReactElement } from 'react';
 
 interface SortableItem {
   id: string;
   label: string;
 }
 export interface SortableItemProps extends SortableItem {
-  renderItem?: (props: SortableItem) => React.ReactElement;
+  renderItem?: (props: SortableItem) => ReactElement;
 }
 
 export interface SortableListProps {

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SpinnerProps } from './Spinner.types';
 
 import Spinner from './Spinner';
-import { SpinnerProps } from './Spinner.types';
 
 export default {
   title: 'components/Spinner',

--- a/src/components/Spinner/Spinner.tsx
+++ b/src/components/Spinner/Spinner.tsx
@@ -1,3 +1,5 @@
+import type { SpinnerProps } from './Spinner.types';
+
 import styled, { keyframes } from 'styled-components';
 import PropTypes from 'prop-types';
 import { pipe, prop, unless } from 'ramda';
@@ -6,7 +8,6 @@ import { transparentize } from 'polished';
 import cls from 'classnames';
 
 import { getColor, pxToRem } from '../../utils';
-import { SpinnerProps } from './Spinner.types';
 import { ColorTypes } from '../../theme';
 import { CLX_COMPONENT } from '../../theme/constants';
 

--- a/src/components/Spinner/Spinner.types.ts
+++ b/src/components/Spinner/Spinner.types.ts
@@ -1,4 +1,4 @@
-import { Color } from '../../theme/colors.types';
+import type { Color } from '../../theme/colors.types';
 
 export interface SpinnerProps {
   dark?: boolean;

--- a/src/components/Stepper/Step.tsx
+++ b/src/components/Stepper/Step.tsx
@@ -1,4 +1,7 @@
-import React, { forwardRef, useContext } from 'react';
+import type { PropsWithChildren } from 'react';
+import type { StepProps } from './Stepper.types';
+
+import { forwardRef, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { isNotUndefined } from 'ramda-adjunct';
@@ -8,7 +11,6 @@ import { SpaceSizes } from '../../theme';
 import { Text } from '../typographyLegacy/Text';
 import { TextSizes, TextVariants } from '../typographyLegacy/Text/Text.enums';
 import { Inline, Padbox, Stack } from '../layout';
-import { StepProps } from './Stepper.types';
 import { StepperContext } from './Stepper.context';
 import { StepperOrientations } from './Stepper.enums';
 import StepBullet, { BulletCircle, bulletSize } from './StepBullet';
@@ -81,7 +83,7 @@ const StepContent = styled.div<{ $isLast?: StepProps['isLast'] }>`
   `};
 `;
 
-const Step = forwardRef<HTMLDivElement, React.PropsWithChildren<StepProps>>(
+const Step = forwardRef<HTMLDivElement, PropsWithChildren<StepProps>>(
   (
     { children, label, summary, index, isLast, shouldShowText, onStepClick },
     ref,

--- a/src/components/Stepper/StepBullet.tsx
+++ b/src/components/Stepper/StepBullet.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { BulletCircleProps, StepBulletProps } from './Stepper.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
@@ -10,7 +12,6 @@ import {
   pxToRem,
 } from '../../utils';
 import { width as checkWidth, svgPathData } from '../../theme/icons/check';
-import { BulletCircleProps, StepBulletProps } from './Stepper.types';
 
 export const bulletSize = 20;
 
@@ -61,7 +62,7 @@ const BULLET_VIEWBOX_SIZE = 20;
 const checkIconRatio = BULLET_VIEWBOX_SIZE / checkWidth / 2;
 const translateX = checkWidth / 2;
 
-const StepBullet: React.FC<StepBulletProps> = ({
+const StepBullet: FC<StepBulletProps> = ({
   stepNumber,
   isActive,
   isPending,

--- a/src/components/Stepper/Stepper.context.ts
+++ b/src/components/Stepper/Stepper.context.ts
@@ -1,5 +1,5 @@
-import { createContext } from 'react';
+import type { StepperContextValue } from './Stepper.types';
 
-import { StepperContextValue } from './Stepper.types';
+import { createContext } from 'react';
 
 export const StepperContext = createContext<StepperContextValue>({});

--- a/src/components/Stepper/Stepper.stories.tsx
+++ b/src/components/Stepper/Stepper.stories.tsx
@@ -1,12 +1,13 @@
-import { Meta, Story } from '@storybook/react/types-6-0';
-import React, { useEffect, useState } from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { StepperProps } from './Stepper.types';
+
+import { useEffect, useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { generateControl } from '../../utils/tests/storybook';
 import { Button } from '../Button';
 import { Inline, Padbox, Stack } from '../layout';
 import { H2, Paragraph } from '../typographyLegacy';
-import { StepperProps } from './Stepper.types';
 import Stepper from './Stepper';
 import Step from './Step';
 import { StepperOrientations } from './Stepper.enums';

--- a/src/components/Stepper/Stepper.test.tsx
+++ b/src/components/Stepper/Stepper.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 
 import Step from './Step';
 import Stepper from './Stepper';

--- a/src/components/Stepper/Stepper.tsx
+++ b/src/components/Stepper/Stepper.tsx
@@ -1,4 +1,7 @@
-import React, { forwardRef, useMemo } from 'react';
+import type { PropsWithChildren, ReactElement } from 'react';
+import type { StepperProps } from './Stepper.types';
+
+import { Children, cloneElement, forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useContainerQuery } from 'react-container-query';
 import { pathEq } from 'ramda';
@@ -6,7 +9,6 @@ import cls from 'classnames';
 
 import { SpaceSizes } from '../../theme';
 import { Inline, Stack } from '../layout';
-import { StepperProps } from './Stepper.types';
 import { mergeRefs } from '../../utils/mergeRefs';
 import { StepperContext } from './Stepper.context';
 import { StepperOrientations } from './Stepper.enums';
@@ -14,10 +16,7 @@ import { CLX_COMPONENT } from '../../theme/constants';
 
 const SHOW_TEXT_BREAKPOINT = 'show-step-text';
 
-const Stepper = forwardRef<
-  HTMLDivElement,
-  React.PropsWithChildren<StepperProps>
->(
+const Stepper = forwardRef<HTMLDivElement, PropsWithChildren<StepperProps>>(
   (
     {
       children,
@@ -38,11 +37,11 @@ const Stepper = forwardRef<
     );
     const [query, containerRef] = useContainerQuery(showTextQuery, undefined);
 
-    const stepsArr: React.ReactElement[] = React.Children.toArray(
-      children,
-    ).filter(pathEq(['type', 'displayName'], 'Step'));
+    const stepsArr: ReactElement[] = Children.toArray(children).filter(
+      pathEq(['type', 'displayName'], 'Step'),
+    );
     const steps = stepsArr.map((step, index) =>
-      React.cloneElement(step, {
+      cloneElement(step, {
         ...step.props,
         index,
         shouldShowText:

--- a/src/components/Stepper/Stepper.types.ts
+++ b/src/components/Stepper/Stepper.types.ts
@@ -1,4 +1,4 @@
-import { StepperOrientations } from './Stepper.enums';
+import type { StepperOrientations } from './Stepper.enums';
 
 export type Orientations =
   typeof StepperOrientations[keyof typeof StepperOrientations];

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { Data } from '../_internal/BaseTable/mocks/types';
+import type { TableProps } from './Table.types';
+
 import { MemoryRouter } from 'react-router-dom';
 import MockDate from 'mockdate';
 import { action } from '@storybook/addon-actions';
 
-import { Data } from '../_internal/BaseTable/mocks/types';
 import assets from '../_internal/BaseTable/mocks/ipAssets.json';
 import { simpleColumns } from '../_internal/BaseTable/mocks/columns';
 import { comparisonTable } from '../_internal/BaseTable/docs';
 import Table from './Table';
-import { TableProps } from './Table.types';
 import { datatableRowActions } from '../Datatable/mocks/actions';
 
 MockDate.set('2021-03-31T00:00:00Z');

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { Column } from 'react-table';
+
 import { screen } from '@testing-library/react';
-import { Column } from 'react-table';
 
 import { renderWithProviders } from '../../utils/tests/renderWithProviders';
 import Table from './Table';

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,14 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { ReactElement } from 'react';
+import type { CellProps, Column } from 'react-table';
+import type { TableProps } from './Table.types';
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import {
-  CellProps,
-  Column,
-  useFlexLayout,
-  usePagination,
-  useSortBy,
-  useTable,
-} from 'react-table';
+import { useFlexLayout, usePagination, useSortBy, useTable } from 'react-table';
 import { prop, F as stubFalse } from 'ramda';
 import { isNonEmptyArray, isNotUndefined, isString, noop } from 'ramda-adjunct';
 
@@ -27,7 +24,6 @@ import {
 import { getColor, getRadii } from '../../utils';
 import { SpaceSizes } from '../../theme';
 import { Padbox } from '../layout';
-import { TableProps } from './Table.types';
 import { RowActionKindsPropType } from '../_internal/BaseTable/BaseTable.types';
 import { CLX_COMPONENT } from '../../theme/constants';
 
@@ -52,7 +48,7 @@ const TableWrapper = styled.div`
 
 const renderDefaultCell = <D extends Record<string, unknown>>(
   props: CellProps<D>,
-): React.ReactElement => <CellRenderer<D> {...props} />;
+): ReactElement => <CellRenderer<D> {...props} />;
 
 function Table<D extends Record<string, unknown>>({
   columns,
@@ -69,15 +65,14 @@ function Table<D extends Record<string, unknown>>({
   onSortChange = noop,
   rowActions = [],
   dataPrimaryKey,
-}: TableProps<D>): React.ReactElement {
+}: TableProps<D>): ReactElement {
   const defaultColumn = useMemo<Partial<Column<D>>>(
     () => ({
       minWidth: 40,
       width: 150,
       maxWidth: 400,
       nullCondition: stubFalse,
-      Cell: (props: CellProps<D>): React.ReactElement =>
-        renderDefaultCell<D>(props),
+      Cell: (props: CellProps<D>): ReactElement => renderDefaultCell<D>(props),
       cellType: 'text',
     }),
     [],

--- a/src/components/Table/Table.types.ts
+++ b/src/components/Table/Table.types.ts
@@ -1,7 +1,9 @@
-import { ReactComponentLike } from 'prop-types';
-import { Column, SortingRule } from 'react-table';
-
-import { PrimaryKey, RowAction } from '../_internal/BaseTable/BaseTable.types';
+import type { ReactComponentLike } from 'prop-types';
+import type { Column, SortingRule } from 'react-table';
+import type {
+  PrimaryKey,
+  RowAction,
+} from '../_internal/BaseTable/BaseTable.types';
 
 export interface TableProps<D extends Record<string, unknown>> {
   /**

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import type { FC, KeyboardEvent } from 'react';
+import type { TabProps } from './Tabs.types';
+
 import PropTypes from 'prop-types';
 
-import { TabProps } from './Tabs.types';
 import { TabVariants } from './Tabs.enums';
 import { ColorTypes } from '../../theme/colors.enums';
 import { requireRouterLink } from '../../utils/require-router-link';
@@ -9,7 +10,7 @@ import { SpaceSizes } from '../../theme/space.enums';
 import { PaddingTypes } from '../layout/Padbox/Padbox.enums';
 import BaseTabLabel from '../_internal/BaseTabs/BaseTabLabel';
 
-const Tab: React.FC<TabProps> = ({
+const Tab: FC<TabProps> = ({
   children,
   isSelected,
   isExpanded = false,
@@ -19,7 +20,7 @@ const Tab: React.FC<TabProps> = ({
   value,
 }) => {
   const isLink = value?.toString()?.startsWith('/');
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLAnchorElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
       onClick(value);
     }

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { TabsProps } from './Tabs.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { MemoryRouter, Route, Switch } from 'react-router-dom';
 
 import { Inline, Stack } from '../layout';
 import { Tab, Tabs } from '.';
-import { TabsProps } from './Tabs.types';
 import { generateControl } from '../../utils/tests/storybook';
 import { TabVariants } from './Tabs.enums';
 import { Icon } from '../Icon';

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import { startsWith } from 'ramda';
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,15 +1,17 @@
-import React from 'react';
+import type { FC, ReactElement } from 'react';
+import type { TabProps, TabsProps } from './Tabs.types';
+
 import PropTypes from 'prop-types';
 import { equals } from 'ramda';
+import { Children, cloneElement, isValidElement } from 'react';
 
 import { Inline } from '../layout';
-import type { TabProps, TabsProps } from './Tabs.types';
 import { TabVariants } from './Tabs.enums';
 import { SpaceSizes } from '../../theme/space.enums';
 import { BaseTabsWrapper } from '../_internal/BaseTabs/BaseTabsWrapper';
 import { CLX_COMPONENT } from '../../theme/constants';
 
-const Tabs: React.FC<TabsProps> = ({
+const Tabs: FC<TabsProps> = ({
   selectedValue,
   selectedPatternMatcher = equals,
   children,
@@ -36,12 +38,12 @@ const Tabs: React.FC<TabsProps> = ({
       role="tablist"
       stretch={isExpanded ? 'all' : 0}
     >
-      {React.Children.map(children, (tab) => {
-        if (!React.isValidElement(tab)) {
+      {Children.map(children, (tab) => {
+        if (!isValidElement(tab)) {
           return null;
         }
 
-        return React.cloneElement(tab as React.ReactElement<TabProps>, {
+        return cloneElement(tab as ReactElement<TabProps>, {
           variant,
           isExpanded,
           key: tab.props.value,

--- a/src/components/Tabs/Tabs.types.ts
+++ b/src/components/Tabs/Tabs.types.ts
@@ -1,29 +1,28 @@
-import React from 'react';
-
-import { SpacingProps } from '../../types/spacing.types';
-import { BaseLabelProps } from '../_internal/BaseTabs/BaseTabLabel.types';
-import { PadboxProps } from '../layout/Padbox/Padbox';
+import type { ReactNode, ReactText } from 'react';
+import type { SpacingProps } from '../../types/spacing.types';
+import type { BaseLabelProps } from '../_internal/BaseTabs/BaseTabLabel.types';
+import type { PadboxProps } from '../layout/Padbox/Padbox';
 
 export interface LabelProps extends BaseLabelProps, PadboxProps {}
 
 export interface TabProps {
-  children: React.ReactNode;
+  children: ReactNode;
   color?: LabelProps['$color'];
   isSelected?: LabelProps['$isSelected'];
   isExpanded?: boolean;
-  onClick?: (selectedValue: React.ReactText) => void;
-  value: React.ReactText;
+  onClick?: (selectedValue: ReactText) => void;
+  value: ReactText;
   variant?: LabelProps['$variant'];
 }
 
 export interface TabsProps extends SpacingProps {
   variant?: LabelProps['$variant'];
-  selectedValue: React.ReactText;
+  selectedValue: ReactText;
   selectedPatternMatcher?: (
-    value: React.ReactText,
-    selectedValue: React.ReactText,
+    value: ReactText,
+    selectedValue: ReactText,
   ) => boolean;
-  onSelectTab?: (selectedValue: React.ReactText) => void;
-  children: React.ReactNode[];
+  onSelectTab?: (selectedValue: ReactText) => void;
+  children: ReactNode[];
   isExpanded?: boolean;
 }

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ToastProps } from './Toast.types';
+
 import { action } from '@storybook/addon-actions';
-import { Meta, Story } from '@storybook/react/types-6-0';
 import { noop } from 'ramda-adjunct';
 
 import Button from '../Button/Button';
@@ -8,7 +9,6 @@ import { Inline, Stack } from '../layout';
 import { SpaceSizes } from '../../theme';
 import Toast from './Toast';
 import { ToastVariants } from './Toast.enums';
-import { ToastProps } from './Toast.types';
 import { generateControl } from '../../utils/tests/storybook';
 
 const styles = {

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { DSProvider, createIconLibrary } from '../../theme';

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { ToastProps } from './Toast.types';
+
 import PropTypes from 'prop-types';
 import { transparentize } from 'polished';
 import styled, { keyframes } from 'styled-components';
@@ -6,7 +8,6 @@ import styled, { keyframes } from 'styled-components';
 import { getColor, getRadii, pxToRem } from '../../utils';
 import { Paragraph } from '../typographyLegacy';
 import { TextSizes } from '../typographyLegacy/Text/Text.enums';
-import { ToastProps } from './Toast.types';
 import { SpaceSizes } from '../../theme/space.enums';
 import { Inline } from '../layout';
 import { StretchEnum } from '../layout/Inline/Inline.enums';
@@ -66,14 +67,14 @@ const iconPxSizesVariants = {
 
 const stopPropagation = (event) => event?.stopPropagation();
 
-const ToastAreaContainer: React.FC<{
+const ToastAreaContainer: FC<{
   isStandalone: boolean;
 }> = ({ children, isStandalone }) => {
   // eslint-disable-next-line
   return isStandalone ? <ToastArea>{children}</ToastArea> : <>{children}</>;
 };
 
-const Toast: React.FC<ToastProps> = ({
+const Toast: FC<ToastProps> = ({
   onClose,
   children,
   width = 400,

--- a/src/components/Toast/Toast.types.ts
+++ b/src/components/Toast/Toast.types.ts
@@ -1,4 +1,4 @@
-import { BaseToastBannerProps } from '../_internal/BaseToastBanner/BaseToastBanner.types';
+import type { BaseToastBannerProps } from '../_internal/BaseToastBanner/BaseToastBanner.types';
 
 export interface ToastProps extends BaseToastBannerProps {
   width?: number;

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ReactChild } from 'react';
+import type { TooltipProps } from './Tooltip.types';
+
 import { omit } from 'ramda';
 
 import { PortalPlacements } from '../../hooks/useCalculatePortalPlacements.enums';
@@ -7,7 +9,6 @@ import { Inline, Padbox, Stack } from '../layout';
 import { Button } from '../Button';
 import { Paragraph } from '../typographyLegacy';
 import Tooltip from './Tooltip';
-import { TooltipProps } from './Tooltip.types';
 import { generateControl } from '../../utils/tests/storybook';
 import { ButtonVariants } from '../Button/Button.enums';
 import { SpaceSizes } from '../../theme';
@@ -47,9 +48,9 @@ const popup = (
   </>
 );
 
-export const Playground: Story<
-  TooltipProps & { children: React.ReactChild }
-> = (args) => <Tooltip {...args} />;
+export const Playground: Story<TooltipProps & { children: ReactChild }> = (
+  args,
+) => <Tooltip {...args} />;
 Playground.args = {
   children: <Button>Button with tooltip</Button>,
   popup,
@@ -91,9 +92,9 @@ export const Placements: Story = () => (
   </Stack>
 );
 
-export const Width: Story<TooltipProps & { children: React.ReactChild }> = (
-  args,
-) => <Tooltip {...args} />;
+export const Width: Story<TooltipProps & { children: ReactChild }> = (args) => (
+  <Tooltip {...args} />
+);
 
 Width.args = {
   ...Playground.args,

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   fireEvent,
   screen,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,12 +1,14 @@
-import React, { useRef } from 'react';
+import type { FC } from 'react';
+import type { TooltipProps } from './Tooltip.types';
+
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { isFalsy } from 'ramda-adjunct';
 
-import { TooltipProps } from './Tooltip.types';
 import { PortalPlacements } from '../../hooks/useCalculatePortalPlacements.enums';
 import { Dropdown } from '../Dropdown';
 
-const Tooltip: React.FC<TooltipProps> = ({
+const Tooltip: FC<TooltipProps> = ({
   children,
   popup,
   placement = PortalPlacements.bottom,

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -1,15 +1,14 @@
-import React from 'react';
-
-import { Placements } from '../Dropdown/Dropdown.types';
+import type { CSSProperties, ReactNode } from 'react';
+import type { Placements } from '../Dropdown/Dropdown.types';
 
 export interface TooltipPopupProps {
   $placement: Placements;
   $width: number;
   $space: number;
-  style: React.CSSProperties;
+  style: CSSProperties;
 }
 export interface TooltipProps {
-  popup?: React.ReactNode;
+  popup?: ReactNode;
   className?: string;
   placement?: Placements;
   width?: number;

--- a/src/components/Tooltip/TooltipPopup.tsx
+++ b/src/components/Tooltip/TooltipPopup.tsx
@@ -1,3 +1,5 @@
+import type { TooltipPopupProps } from './Tooltip.types';
+
 import styled, { css } from 'styled-components';
 
 import { SpaceSizes } from '../../theme';
@@ -11,7 +13,6 @@ import {
   pxToRem,
 } from '../../utils';
 import { Padbox } from '../layout';
-import { TooltipPopupProps } from './Tooltip.types';
 
 const bottomPlacement = ({ $space, $width }) => css`
   &::before {

--- a/src/components/UserAvatar/UserAvatar.stories.tsx
+++ b/src/components/UserAvatar/UserAvatar.stories.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { UserAvatarProps } from './UserAvatar.types';
+
 import { action } from '@storybook/addon-actions';
 
 import { generateControl } from '../../utils/tests/storybook';
 import UserAvatar from './UserAvatar';
-import { UserAvatarProps } from './UserAvatar.types';
 import { UserAvatarSizes } from './UserAvatar.enums';
 import { Inline } from '../layout';
 import { SpaceSizes } from '../../theme';

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { UserAvatarProps, UserAvatarRootProps } from './UserAvatar.types';
+
 import styled, { css } from 'styled-components';
 import { any, pipe, take, toUpper, trim } from 'ramda';
 import { isNotUndefined } from 'ramda-adjunct';
@@ -6,7 +8,6 @@ import PropTypes from 'prop-types';
 import cls from 'classnames';
 
 import { ButtonColors, ButtonVariants } from '../Button/Button.enums';
-import type { UserAvatarProps, UserAvatarRootProps } from './UserAvatar.types';
 import {
   getColor,
   getFontFamily,
@@ -73,7 +74,7 @@ const RootUserAvatar = styled.div<UserAvatarRootProps>`
 `;
 const normalizeString = pipe(trim, take(2), toUpper);
 
-const UserAvatar: React.FC<UserAvatarProps> = ({
+const UserAvatar: FC<UserAvatarProps> = ({
   label,
   size = UserAvatarSizes.md,
   className,

--- a/src/components/UserAvatar/UserAvatar.types.ts
+++ b/src/components/UserAvatar/UserAvatar.types.ts
@@ -1,6 +1,6 @@
 import type { To } from 'history';
-
-import { UserAvatarSizes } from './UserAvatar.enums';
+import type { MouseEventHandler } from 'react';
+import type { UserAvatarSizes } from './UserAvatar.enums';
 
 export type Sizes = typeof UserAvatarSizes[keyof typeof UserAvatarSizes];
 
@@ -26,5 +26,5 @@ export interface UserAvatarProps {
   isInverted?: UserAvatarRootProps['$isInverted'];
   href?: string;
   to?: To;
-  onClick?: React.MouseEventHandler;
+  onClick?: MouseEventHandler;
 }

--- a/src/components/Wizard/Wizard.context.tsx
+++ b/src/components/Wizard/Wizard.context.tsx
@@ -1,12 +1,7 @@
-import React, {
-  Dispatch,
-  SetStateAction,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import type { Dispatch, FC, ReactNode, SetStateAction } from 'react';
+import type { WizardStep } from './Wizard.types';
 
-import { WizardStep } from './Wizard.types';
+import { createContext, useEffect, useMemo, useState } from 'react';
 
 export interface WizardState {
   initialStep?: string;
@@ -16,7 +11,7 @@ export interface WizardState {
   update: Dispatch<SetStateAction<WizardState>>;
 }
 
-export const WizardContext = React.createContext<WizardState>({
+export const WizardContext = createContext<WizardState>({
   initialStep: undefined,
   activeStepId: undefined,
   steps: [],
@@ -25,13 +20,13 @@ export const WizardContext = React.createContext<WizardState>({
 });
 
 interface WizardProviderProps {
-  children: React.ReactNode;
+  children: ReactNode;
   initialStep: string;
   isBackwardNavigationEnabled: boolean;
   onStepChange: (step: WizardStep) => void;
 }
 
-export const WizardProvider: React.FC<WizardProviderProps> = ({
+export const WizardProvider: FC<WizardProviderProps> = ({
   children,
   initialStep,
   isBackwardNavigationEnabled,

--- a/src/components/Wizard/Wizard.stories.tsx
+++ b/src/components/Wizard/Wizard.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import { action } from '@storybook/addon-actions';
 
 import Wizard from './Wizard';

--- a/src/components/Wizard/Wizard.tsx
+++ b/src/components/Wizard/Wizard.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { WizardProps } from './Wizard.types';
+
 import PropTypes from 'prop-types';
 
 import { Inline, Stack } from '../layout';
 import { Modal } from '../Modal';
 import { ModalSizes } from '../Modal/Modal.enums';
 import { WizardProvider } from './Wizard.context';
-import { WizardProps } from './Wizard.types';
 import { WizardActions } from './WizardActions';
 import { WizardStepper } from './WizardStepper';
 
-const Wizard: React.FC<WizardProps> = ({
+const Wizard: FC<WizardProps> = ({
   initialStep,
   size = ModalSizes.lg,
   onStepChange = () => null,

--- a/src/components/Wizard/Wizard.types.ts
+++ b/src/components/Wizard/Wizard.types.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import type { ReactNode } from 'react';
+import type { Sizes } from '../Modal/Modal.types';
 
-import { Sizes } from '../Modal/Modal.types';
+import PropTypes from 'prop-types';
 
 export interface WizardProps {
   size?: Sizes;
@@ -9,7 +9,7 @@ export interface WizardProps {
   onClose?: () => void;
   isBackwardNavigationEnabled?: boolean;
   onStepChange?: (step: WizardStep) => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export interface WizardStep {
@@ -38,5 +38,5 @@ export interface WizardNavigation {
 }
 
 export type WizardStepProps = WizardStep & {
-  children: React.ReactNode;
+  children: ReactNode;
 };

--- a/src/components/Wizard/WizardActions.tsx
+++ b/src/components/Wizard/WizardActions.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Button } from '../Button';
 import { Inline } from '../layout';
 import { useActiveStep } from './hooks/useActiveStep';

--- a/src/components/Wizard/WizardStep.tsx
+++ b/src/components/Wizard/WizardStep.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { WizardStepProps } from './Wizard.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import { useRegisterStep } from './hooks/useRegisterStep';
-import { WizardActionPropType, WizardStepProps } from './Wizard.types';
+import { WizardActionPropType } from './Wizard.types';
 import { useActiveStep } from './hooks/useActiveStep';
 import { pxToRem } from '../../utils';
 
@@ -12,7 +14,7 @@ const StepContainer = styled.div`
   height: ${pxToRem(418)};
 `;
 
-const WizardStep: React.FC<WizardStepProps> = ({
+const WizardStep: FC<WizardStepProps> = ({
   children,
   ...step
 }: WizardStepProps) => {

--- a/src/components/Wizard/WizardStepper.tsx
+++ b/src/components/Wizard/WizardStepper.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Step, Stepper } from '../Stepper';
 import { useActiveStep } from './hooks/useActiveStep';
 import { useWizardContext } from './hooks/useWizardContext';

--- a/src/components/Wizard/hooks/useRegisterStep.ts
+++ b/src/components/Wizard/hooks/useRegisterStep.ts
@@ -1,7 +1,8 @@
+import type { WizardStep } from '../Wizard.types';
+
 import { useEffect } from 'react';
 
 import { useWizardContext } from './useWizardContext';
-import { WizardStep } from '../Wizard.types';
 
 export const useRegisterStep = (step: WizardStep) => {
   const { update } = useWizardContext();

--- a/src/components/Wizard/hooks/useWizardContext.ts
+++ b/src/components/Wizard/hooks/useWizardContext.ts
@@ -1,6 +1,8 @@
+import type { WizardState } from '../Wizard.context';
+
 import { useContext } from 'react';
 
-import { WizardContext, WizardState } from '../Wizard.context';
+import { WizardContext } from '../Wizard.context';
 
 export const useWizardContext = () => {
   return useContext<WizardState>(WizardContext);

--- a/src/components/Wizard/hooks/useWizardNavigation.ts
+++ b/src/components/Wizard/hooks/useWizardNavigation.ts
@@ -1,5 +1,6 @@
+import type { WizardNavigation, WizardStep } from '../Wizard.types';
+
 import { useWizardContext } from './useWizardContext';
-import { WizardNavigation, WizardStep } from '../Wizard.types';
 import { useActiveStep } from './useActiveStep';
 
 export const useWizardNavigation = (): WizardNavigation => {

--- a/src/components/WizardModal/WizardModal.stories.tsx
+++ b/src/components/WizardModal/WizardModal.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { WizardModalProps } from './WizardModal.types';
+
 import { action } from '@storybook/addon-actions';
 
 import WizardModal from './WizardModal';
-import { WizardModalProps } from './WizardModal.types';
 import { Inline, Padbox, Stack } from '../layout';
 import { H2, Paragraph } from '../typographyLegacy';
 import { Button, ButtonEnums } from '../Button';

--- a/src/components/WizardModal/WizardModal.tsx
+++ b/src/components/WizardModal/WizardModal.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { WizardModalProps } from './WizardModal.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 import { usePortal } from '../../hooks/usePortal';
 import { useLockBodyScroll } from '../../hooks/useLockBodyScroll';
 import { getColor, getDepth, getRadii } from '../../utils';
-import { WizardModalProps } from './WizardModal.types';
 import { Padbox } from '../layout';
 
 const BlurredOverlay = styled.div`
@@ -33,7 +34,7 @@ const BaseModal = styled(Padbox)`
   }
 `;
 
-const WizardModal: React.FC<WizardModalProps> = ({ children }) => {
+const WizardModal: FC<WizardModalProps> = ({ children }) => {
   const { Portal } = usePortal();
   useLockBodyScroll();
 

--- a/src/components/WizardModal/WizardModal.types.ts
+++ b/src/components/WizardModal/WizardModal.types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 export interface WizardModalProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }

--- a/src/components/_internal/BaseButton/BaseButton.tsx
+++ b/src/components/_internal/BaseButton/BaseButton.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import type { ComponentProps, FC } from 'react';
+import type { SSCIcons, Types } from '../../Icon/Icon.types';
+import type { BaseButtonProps } from './BaseButton.types';
+
 import PropTypes from 'prop-types';
 import {
   isNotNull,
@@ -18,7 +21,6 @@ import { SpacingSizeValuePropType } from '../../../types/spacing.types';
 import { PaddingTypes } from '../../layout/Padbox/Padbox.enums';
 import { Spinner } from '../../Spinner';
 import { Icon } from '../../Icon';
-import { SSCIcons, Types } from '../../Icon/Icon.types';
 import { Inline } from '../../layout';
 import BaseStyledButton from './BaseStyledButton';
 import {
@@ -26,7 +28,6 @@ import {
   BaseButtonSizes,
   BaseButtonVariants,
 } from './BaseButton.enums';
-import { BaseButtonProps } from './BaseButton.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 import { useLogger } from '../../../hooks/useLogger';
 
@@ -34,8 +35,8 @@ const BaseStyledIcon = styled(Icon)`
   font-size: ${getToken('font-action-size')};
 `;
 
-const BaseButton: React.FC<
-  BaseButtonProps & React.ComponentProps<typeof BaseStyledButton>
+const BaseButton: FC<
+  BaseButtonProps & ComponentProps<typeof BaseStyledButton>
 > = ({
   children,
   variant = BaseButtonVariants.solid,

--- a/src/components/_internal/BaseButton/BaseButton.types.ts
+++ b/src/components/_internal/BaseButton/BaseButton.types.ts
@@ -1,15 +1,14 @@
-import React from 'react';
+import type { HTMLProps, MouseEventHandler } from 'react';
 import type { To } from 'history';
-import { DefaultTheme } from 'styled-components';
-
-import { SpacingSizeValue } from '../../../types/spacing.types';
-import { Types as IconTypes, SSCIcons } from '../../Icon/Icon.types';
-import {
+import type { DefaultTheme } from 'styled-components';
+import type { SpacingSizeValue } from '../../../types/spacing.types';
+import type { Types as IconTypes, SSCIcons } from '../../Icon/Icon.types';
+import type {
   BaseButtonColors,
   BaseButtonSizes,
   BaseButtonVariants,
 } from './BaseButton.enums';
-import { PadboxProps } from '../../layout/Padbox/Padbox';
+import type { PadboxProps } from '../../layout/Padbox/Padbox';
 
 export type Variants =
   typeof BaseButtonVariants[keyof typeof BaseButtonVariants];
@@ -17,11 +16,11 @@ export type Sizes = typeof BaseButtonSizes[keyof typeof BaseButtonSizes];
 export type Colors = typeof BaseButtonColors[keyof typeof BaseButtonColors];
 
 export interface BaseButtonProps
-  extends Omit<React.HTMLProps<HTMLButtonElement>, 'size' | 'as'> {
+  extends Omit<HTMLProps<HTMLButtonElement>, 'size' | 'as'> {
   variant?: Variants;
   size?: Sizes;
   color?: Colors;
-  onClick?: React.MouseEventHandler;
+  onClick?: MouseEventHandler;
   isDisabled?: boolean;
   isLoading?: boolean;
   isExpanded?: boolean;

--- a/src/components/_internal/BaseButton/BaseStyledButton.tsx
+++ b/src/components/_internal/BaseButton/BaseStyledButton.tsx
@@ -1,3 +1,5 @@
+import type { BaseStyledButtonProps } from './BaseButton.types';
+
 import styled, { css } from 'styled-components';
 import { includes, pipe } from 'ramda';
 
@@ -9,7 +11,6 @@ import {
   getToken,
   pxToRem,
 } from '../../../utils';
-import { BaseStyledButtonProps } from './BaseButton.types';
 import { BaseButtonVariants } from './BaseButton.enums';
 import { Padbox } from '../../layout';
 import { ButtonColors } from '../../Button/Button.enums';

--- a/src/components/_internal/BaseDateRangePicker/BaseDateRangePicker.tsx
+++ b/src/components/_internal/BaseDateRangePicker/BaseDateRangePicker.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { BaseDateRangePickerProps } from './BaseDateRangePicker.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { any, prop } from 'ramda';
@@ -7,7 +9,6 @@ import { isNotNull } from 'ramda-adjunct';
 import { dateRangePickerStyles } from './styles';
 import {
   BaseDateRangePickerPropTypes,
-  BaseDateRangePickerProps,
   BaseDateRangePlaceholderPropTypes,
 } from './BaseDateRangePicker.types';
 import { BaseSingleDatePicker } from '../BaseSingleDatePicker';
@@ -23,7 +24,7 @@ const StyledDatePicker = styled.div`
 
 const isRangeDefined = any(isNotNull);
 
-const BaseDateRangePicker: React.FC<BaseDateRangePickerProps> = ({
+const BaseDateRangePicker: FC<BaseDateRangePickerProps> = ({
   value = { startDate: null, endDate: null },
   onChange,
   minDate,

--- a/src/components/_internal/BaseDropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/_internal/BaseDropdownMenu/DropdownMenu.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 
 import { renderWithProviders } from '../../../utils/tests/renderWithProviders';
 import DropdownMenu from './DropdownMenu';

--- a/src/components/_internal/BaseDropdownMenu/DropdownMenu.tsx
+++ b/src/components/_internal/BaseDropdownMenu/DropdownMenu.tsx
@@ -1,15 +1,21 @@
-import React, { useRef, useState } from 'react';
+import type { FC, MouseEvent, ReactElement } from 'react';
+import type {
+  AbsoluteLinkActionKind,
+  RelativeLinkActionKind,
+} from '../../../types/action.types';
+import type {
+  DropdownLinkProps,
+  DropdownMenuProps,
+} from './DropdownMenu.types';
+import type { InteractiveElement } from '../../Dropdown/Dropdown.types';
+
+import { memo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { isFunction, isNotUndefined, isNull, noop } from 'ramda-adjunct';
 import cls from 'classnames';
 
-import {
-  AbsoluteLinkActionKind,
-  ActionKindsPropType,
-  RelativeLinkActionKind,
-} from '../../../types/action.types';
-import { DropdownLinkProps, DropdownMenuProps } from './DropdownMenu.types';
+import { ActionKindsPropType } from '../../../types/action.types';
 import { getColor, getSpace, pxToRem } from '../../../utils';
 import { requireRouterLink } from '../../../utils/require-router-link';
 import { Dropdown } from '../../Dropdown';
@@ -17,7 +23,6 @@ import { SpaceSizes } from '../../../theme/space.enums';
 import { Text, TextEnums } from '../../typographyLegacy';
 import { Padbox, PadboxEnums } from '../../layout';
 import { CLX_COMPONENT } from '../../../theme/constants';
-import { InteractiveElement } from '../../Dropdown/Dropdown.types';
 
 export const List = styled.ul`
   list-style: none;
@@ -53,7 +58,7 @@ const getOptions = () => {
   );
 };
 
-const DropdownMenu: React.FC<DropdownMenuProps> = ({
+const DropdownMenu: FC<DropdownMenuProps> = ({
   actions,
   defaultIsOpen = false,
   paneWidth = 'auto',
@@ -68,7 +73,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
     showPane: noop,
   });
   const containerRef = useRef(null);
-  const trigger: React.ReactElement = (
+  const trigger: ReactElement = (
     <span className={cls(CLX_COMPONENT, className)}>
       {isFunction(children) ? children(isActive) : children}
     </span>
@@ -119,21 +124,18 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
           let RouterLink = null;
           if (
             isNotUndefined(
-              (action as RelativeLinkActionKind<React.MouseEvent[], boolean>)
-                .to,
+              (action as RelativeLinkActionKind<MouseEvent[], boolean>).to,
             )
           ) {
             RouterLink = requireRouterLink();
           }
 
           const domTag = isNotUndefined(
-            (action as AbsoluteLinkActionKind<React.MouseEvent[], boolean>)
-              .href,
+            (action as AbsoluteLinkActionKind<MouseEvent[], boolean>).href,
           )
             ? 'a' // render 'a' tag if 'href' is present
             : isNotUndefined(
-                (action as RelativeLinkActionKind<React.MouseEvent[], boolean>)
-                  .to,
+                (action as RelativeLinkActionKind<MouseEvent[], boolean>).to,
               )
             ? RouterLink // render 'Link' if 'to' is present
             : 'button'; // use default
@@ -141,8 +143,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
           if (
             isNull(RouterLink) &&
             isNotUndefined(
-              (action as RelativeLinkActionKind<React.MouseEvent[], boolean>)
-                .to,
+              (action as RelativeLinkActionKind<MouseEvent[], boolean>).to,
             )
           ) {
             return null;
@@ -159,23 +160,13 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
                 data-dropdown-item="true"
                 data-interactive="true"
                 href={
-                  (
-                    action as AbsoluteLinkActionKind<
-                      React.MouseEvent[],
-                      boolean
-                    >
-                  ).href
+                  (action as AbsoluteLinkActionKind<MouseEvent[], boolean>).href
                 }
                 name={action.name}
                 paddingSize={SpaceSizes.md}
                 paddingType={PadboxEnums.PaddingTypes.squish}
                 to={
-                  (
-                    action as RelativeLinkActionKind<
-                      React.MouseEvent[],
-                      boolean
-                    >
-                  ).to
+                  (action as RelativeLinkActionKind<MouseEvent[], boolean>).to
                 }
                 onClick={(event) => {
                   action.onClick(event);
@@ -206,4 +197,4 @@ DropdownMenu.propTypes = {
   placement: PropTypes.oneOf(['bottom', 'bottom-start', 'bottom-end']),
 };
 
-export default React.memo(DropdownMenu);
+export default memo(DropdownMenu);

--- a/src/components/_internal/BaseDropdownMenu/DropdownMenu.types.ts
+++ b/src/components/_internal/BaseDropdownMenu/DropdownMenu.types.ts
@@ -1,9 +1,11 @@
 import type { To } from 'history';
+import type { MouseEvent, ReactNode } from 'react';
+import type { ActionKinds } from '../../../types/action.types';
+import type { Placements } from '../../Dropdown/Dropdown.types';
+
 import { pick } from 'ramda';
 
-import { ActionKinds } from '../../../types/action.types';
 import { DropdownPlacements } from '../../Dropdown/Dropdown.enums';
-import { Placements } from '../../Dropdown/Dropdown.types';
 
 export interface DropdownLinkProps {
   name: string;
@@ -19,8 +21,8 @@ export const ControlDropdownPlacements = pick([
 ])(DropdownPlacements);
 
 export interface DropdownMenuProps {
-  actions: ActionKinds<React.MouseEvent[]>[];
-  children: React.ReactNode | ((isActive: boolean) => JSX.Element);
+  actions: ActionKinds<MouseEvent[]>[];
+  children: ReactNode | ((isActive: boolean) => JSX.Element);
   defaultIsOpen?: boolean;
   paneWidth?: 'auto' | number;
   className?: string;

--- a/src/components/_internal/BaseLink/BaseLink.ts
+++ b/src/components/_internal/BaseLink/BaseLink.ts
@@ -1,7 +1,8 @@
+import type { Colors } from './BaseLink.types';
+
 import { css } from 'styled-components';
 
 import { getFontWeight, getRadii, getToken } from '../../../utils';
-import { Colors } from './BaseLink.types';
 
 type LinkStylesProps = { $color: Colors };
 

--- a/src/components/_internal/BaseLink/BaseLink.types.ts
+++ b/src/components/_internal/BaseLink/BaseLink.types.ts
@@ -1,3 +1,3 @@
-import { LinkColors } from './BaseLink.enums';
+import type { LinkColors } from './BaseLink.enums';
 
 export type Colors = typeof LinkColors[keyof typeof LinkColors];

--- a/src/components/_internal/BaseSingleDatePicker/CustomHeader.tsx
+++ b/src/components/_internal/BaseSingleDatePicker/CustomHeader.tsx
@@ -1,5 +1,7 @@
+import type { FC } from 'react';
+
 import styled from 'styled-components';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { PaddingTypes } from '../../layout/Padbox/Padbox.enums';
 import { SSCIconNames } from '../../../theme/icons/icons.enums';
@@ -71,7 +73,7 @@ const MonthIndicator = styled.button`
   }
 `;
 
-export const DatePickerCustomHeader: React.FC<{
+export const DatePickerCustomHeader: FC<{
   decreaseMonth: () => void;
   increaseMonth: () => void;
   increaseYear: () => void;

--- a/src/components/_internal/BaseSingleDatePicker/SingleDatePicker.tsx
+++ b/src/components/_internal/BaseSingleDatePicker/SingleDatePicker.tsx
@@ -1,11 +1,13 @@
-import React, { useRef, useState } from 'react';
+import type { FC } from 'react';
+import type { SingleDatePickerProps } from './SingleDatePicker.types';
+
+import { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { noop } from 'ramda-adjunct';
 import DatePicker from 'react-datepicker';
 
 import { datePickerStyles, singleDatePickerStyles } from './styles';
-import { SingleDatePickerProps } from './SingleDatePicker.types';
 import { DatePickerCustomHeader } from './CustomHeader';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
@@ -14,7 +16,7 @@ export const StyledDatePicker = styled.div`
   ${singleDatePickerStyles}
 `;
 
-const SingleDatePicker: React.FC<SingleDatePickerProps> = ({
+const SingleDatePicker: FC<SingleDatePickerProps> = ({
   value = null,
   onChange = noop,
   minDate,

--- a/src/components/_internal/BaseTable/BaseTable.types.ts
+++ b/src/components/_internal/BaseTable/BaseTable.types.ts
@@ -1,5 +1,6 @@
 import type { To } from 'history';
 import type { Row } from 'react-table';
+
 import PropTypes from 'prop-types';
 
 import { ActionBasePropType } from '../../../types/action.types';

--- a/src/components/_internal/BaseTable/Body/Body.tsx
+++ b/src/components/_internal/BaseTable/Body/Body.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+import type { BodyProps } from './Body.types';
+
 import { isNotUndefined, isOdd } from 'ramda-adjunct';
 import cls from 'classnames';
 
-import { BodyProps } from './Body.types';
 import { shrinkIfSticky } from '../utils';
 
 function Body<D extends Record<string, unknown>>({
   rows,
   prepareRow,
   ...bodyProps
-}: BodyProps<D>): React.ReactElement {
+}: BodyProps<D>): ReactElement {
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
     <tbody {...bodyProps}>

--- a/src/components/_internal/BaseTable/Body/Body.types.ts
+++ b/src/components/_internal/BaseTable/Body/Body.types.ts
@@ -1,4 +1,4 @@
-import { Row, TableBodyProps } from 'react-table';
+import type { Row, TableBodyProps } from 'react-table';
 
 export interface BodyProps<D extends Record<string, unknown>>
   extends TableBodyProps {

--- a/src/components/_internal/BaseTable/Footer/Footer.stories.tsx
+++ b/src/components/_internal/BaseTable/Footer/Footer.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { FooterProps } from './Footer.types';
+
 import { action } from '@storybook/addon-actions';
 
 import Footer from './Footer';
-import { FooterProps } from './Footer.types';
 
 export default {
   title: 'components/Datatable/internalComponents/Table/Footer',

--- a/src/components/_internal/BaseTable/Footer/Footer.tsx
+++ b/src/components/_internal/BaseTable/Footer/Footer.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { FooterProps } from './Footer.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import { pxToRem } from '../../../../utils';
 import { Padbox } from '../../../layout';
 import { Spinner } from '../../../Spinner';
-import { FooterProps } from './Footer.types';
 import GoToPage from './GoToPage';
 import { Pagination } from '../../../Pagination';
 import { SpaceSizes } from '../../../../theme';
@@ -22,7 +23,7 @@ const PaginationContainer = styled.div`
   flex: 1 0 auto;
 `;
 
-const Footer: React.FC<FooterProps> = ({
+const Footer: FC<FooterProps> = ({
   pageCount,
   pageButtonsCount,
   pageIndex,

--- a/src/components/_internal/BaseTable/Footer/Footer.types.ts
+++ b/src/components/_internal/BaseTable/Footer/Footer.types.ts
@@ -1,4 +1,4 @@
-import { OnPageChangeFn } from '../../../Pagination/Pagination.types';
+import type { OnPageChangeFn } from '../../../Pagination/Pagination.types';
 
 export interface FooterProps {
   pageCount: number;

--- a/src/components/_internal/BaseTable/Footer/GoToPage.test.tsx
+++ b/src/components/_internal/BaseTable/Footer/GoToPage.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/_internal/BaseTable/Footer/GoToPage.tsx
+++ b/src/components/_internal/BaseTable/Footer/GoToPage.tsx
@@ -1,4 +1,7 @@
-import React, { useRef } from 'react';
+import type { FC, KeyboardEvent } from 'react';
+import type { GoToPageProps } from './GoToPage.types';
+
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -10,7 +13,6 @@ import {
 } from '../../../../utils';
 import { Inline } from '../../../layout';
 import { Input } from '../../../forms';
-import { GoToPageProps } from './GoToPage.types';
 import { SpaceSizes } from '../../../../theme';
 
 const SmallInput = styled(Input)`
@@ -37,9 +39,9 @@ const GoToPageLabel = styled.label`
   color: ${getColor('neutral.700')};
 `;
 
-const GoToPage: React.FC<GoToPageProps> = ({ pageCount, onPageChange }) => {
+const GoToPage: FC<GoToPageProps> = ({ pageCount, onPageChange }) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const handlePageChange = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handlePageChange = (e: KeyboardEvent<HTMLInputElement>) => {
     const { target, key } = e;
     const { value } = target as HTMLInputElement;
     const parsedValue = parseInt(value, 10);

--- a/src/components/_internal/BaseTable/Footer/GoToPage.types.ts
+++ b/src/components/_internal/BaseTable/Footer/GoToPage.types.ts
@@ -1,4 +1,4 @@
-import { OnPageChangeFn } from '../../../Pagination/Pagination.types';
+import type { OnPageChangeFn } from '../../../Pagination/Pagination.types';
 
 export interface GoToPageProps {
   pageCount: number;

--- a/src/components/_internal/BaseTable/Head/Head.tsx
+++ b/src/components/_internal/BaseTable/Head/Head.tsx
@@ -1,5 +1,7 @@
+import type { ReactElement } from 'react';
+import type { HeadProps } from './Head.types';
+
 import { isNotUndefined } from 'ramda-adjunct';
-import React from 'react';
 import styled, { css } from 'styled-components';
 
 import {
@@ -12,7 +14,6 @@ import {
 import TooltipWrapper from '../components/TooltipWrapper';
 import { makeStickyColumn, shrinkIfSticky } from '../utils';
 import SortingIcon from './SortingIcon';
-import { HeadProps } from './Head.types';
 
 const StyledTh = styled.th`
   display: flex;
@@ -47,7 +48,7 @@ const StyledTh = styled.th`
 
 function Head<D extends Record<string, unknown>>({
   headerGroups,
-}: HeadProps<D>): React.ReactElement {
+}: HeadProps<D>): ReactElement {
   return (
     <thead>
       {headerGroups.map((headerGroup) => (

--- a/src/components/_internal/BaseTable/Head/Head.types.ts
+++ b/src/components/_internal/BaseTable/Head/Head.types.ts
@@ -1,4 +1,4 @@
-import { HeaderGroup } from 'react-table';
+import type { HeaderGroup } from 'react-table';
 
 export interface SortingIconProps {
   isSorted: boolean;

--- a/src/components/_internal/BaseTable/Head/SortingIcon.tsx
+++ b/src/components/_internal/BaseTable/Head/SortingIcon.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import type { ComponentProps, FC } from 'react';
+import type { SortingIconProps } from './Head.types';
+
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
@@ -6,13 +9,12 @@ import { SSCIconNames } from '../../../../theme/icons/icons.enums';
 import { ColorTypes } from '../../../../theme/colors.enums';
 import { pxToRem } from '../../../../utils';
 import { Icon } from '../../../Icon';
-import { SortingIconProps } from './Head.types';
 
 const StyledIcon = styled(Icon).attrs((props) => ({
   color: ColorTypes.neutral700,
   margin: { left: 0.3 },
   ...props,
-}))<{ $isActive?: boolean } & React.ComponentProps<typeof Icon>>`
+}))<{ $isActive?: boolean } & ComponentProps<typeof Icon>>`
   font-size: ${pxToRem(10)};
 
   ${({ $isActive }) =>
@@ -22,16 +24,12 @@ const StyledIcon = styled(Icon).attrs((props) => ({
     `};
 `;
 
-const SortingIcon: React.FC<SortingIconProps> = React.memo(
-  ({ isSorted, isSortedDesc }) => {
-    if (isSortedDesc)
-      return <StyledIcon name={SSCIconNames.sortDown} $isActive />;
-    if (isSorted) return <StyledIcon name={SSCIconNames.sortUp} $isActive />;
-    return (
-      <StyledIcon color={ColorTypes.neutral500} name={SSCIconNames.sort} />
-    );
-  },
-);
+const SortingIcon: FC<SortingIconProps> = memo(({ isSorted, isSortedDesc }) => {
+  if (isSortedDesc)
+    return <StyledIcon name={SSCIconNames.sortDown} $isActive />;
+  if (isSorted) return <StyledIcon name={SSCIconNames.sortUp} $isActive />;
+  return <StyledIcon color={ColorTypes.neutral500} name={SSCIconNames.sort} />;
+});
 
 SortingIcon.propTypes = {
   isSorted: PropTypes.bool,

--- a/src/components/_internal/BaseTable/columns/actionsColumn.tsx
+++ b/src/components/_internal/BaseTable/columns/actionsColumn.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+import type { CellProps } from 'react-table';
+
 import { map } from 'ramda';
 import styled, { css } from 'styled-components';
-import { CellProps } from 'react-table';
 
 import { Inline } from '../../../layout';
 import { DropdownMenu } from '../../BaseDropdownMenu';
@@ -49,7 +50,7 @@ export const actionsColumn = {
   width: 48,
   disableSortBy: true,
   cellType: CellTypes.actions,
-  Cell: (props: CellProps<Record<string, unknown>>): React.ReactElement => {
+  Cell: (props: CellProps<Record<string, unknown>>): ReactElement => {
     const { row, rowActions } = props;
     const actions = map((action) => ({
       ...action,

--- a/src/components/_internal/BaseTable/components/LoadingNoData.tsx
+++ b/src/components/_internal/BaseTable/components/LoadingNoData.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
-
 import { H4, Paragraph } from '../../../typographyLegacy';
 import { Inline } from '../../../layout';
 import { Spinner } from '../../../Spinner';
 import { TextSizes } from '../../../typographyLegacy/Text/Text.enums';
 import { SpaceSizes } from '../../../../theme';
 
-const LoadingNoData: React.FC = () => (
+const LoadingNoData = () => (
   <>
     <Inline align="center" gap={SpaceSizes.sm}>
       <Spinner

--- a/src/components/_internal/BaseTable/components/NoData.tsx
+++ b/src/components/_internal/BaseTable/components/NoData.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
-
 import { H4, Paragraph } from '../../../typographyLegacy';
 import { TextSizes } from '../../../typographyLegacy/Text/Text.enums';
 
-const NoData: React.FC = () => (
+const NoData = () => (
   <>
     <H4 margin={{ top: 0, bottom: 0.8 }}>No data available</H4>
     <Paragraph margin={{ bottom: 0.8 }} size={TextSizes.md}>

--- a/src/components/_internal/BaseTable/components/TooltipWrapper.tsx
+++ b/src/components/_internal/BaseTable/components/TooltipWrapper.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { TooltipWrapperProps } from './TooltipWrapper.types';
+
 import PropTypes from 'prop-types';
 
 import { Tooltip } from '../../../Tooltip';
-import { TooltipWrapperProps } from './TooltipWrapper.types';
 
-const TooltipWrapper: React.FC<TooltipWrapperProps> = ({
+const TooltipWrapper: FC<TooltipWrapperProps> = ({
   popupRenderer,
   shouldRender,
   children,

--- a/src/components/_internal/BaseTable/components/TooltipWrapper.types.ts
+++ b/src/components/_internal/BaseTable/components/TooltipWrapper.types.ts
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { ReactElement } from 'react';
 
 export interface TooltipWrapperProps {
-  popupRenderer: () => React.ReactElement;
+  popupRenderer: () => ReactElement;
   shouldRender: boolean;
 }

--- a/src/components/_internal/BaseTable/mocks/columns.tsx
+++ b/src/components/_internal/BaseTable/mocks/columns.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+import type { CellProps, Column } from 'react-table';
+import type { Data } from './types';
+
+import { memo } from 'react';
 import { action } from '@storybook/addon-actions';
-import { CellProps, Column } from 'react-table';
 import { Link as RouterLink } from 'react-router-dom';
 import { pipe, reduce, toPairs } from 'ramda';
 import dayjs from 'dayjs';
@@ -13,7 +16,6 @@ import {
 import { Strong, Text } from '../../../typographyLegacy';
 import { Tooltip } from '../../../Tooltip';
 import { abbreviateNumber } from '../../../../utils';
-import { Data } from './types';
 
 export const composeQuery = pipe(
   toPairs,
@@ -34,7 +36,7 @@ export const simpleColumns: Column<Data>[] = [
     headerTooltip: <Text>Show status of the asset.</Text>,
     accessor: 'status',
     width: 96,
-    Cell: React.memo(({ value }: { value: string }): React.ReactElement => {
+    Cell: memo(({ value }: { value: string }): ReactElement => {
       switch (value) {
         case 'Removed':
         case 'Dynamic':
@@ -55,7 +57,7 @@ export const simpleColumns: Column<Data>[] = [
     Header: 'Domains',
     accessor: 'domainsCount',
     width: 96,
-    cellTooltipPopupComposer: (val: string, row: Data): React.ReactElement => (
+    cellTooltipPopupComposer: (val: string, row: Data): ReactElement => (
       <div>
         <div>{val}</div>
         <pre>
@@ -129,7 +131,7 @@ export const simpleColumns: Column<Data>[] = [
       row: {
         original: { observationDate, lastObservationDate },
       },
-    }: CellProps<Data>): React.ReactElement => {
+    }: CellProps<Data>): ReactElement => {
       dayjs.extend(relativeTime);
 
       return (

--- a/src/components/_internal/BaseTable/renderers/CellRenderer.test.tsx
+++ b/src/components/_internal/BaseTable/renderers/CellRenderer.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import type { Row } from 'react-table';
+
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { identity, F as stubFalse } from 'ramda';
-import { Row } from 'react-table';
 
 import { renderWithProviders } from '../../../../utils/tests/renderWithProviders';
 import CellRenderer from './CellRenderer';

--- a/src/components/_internal/BaseTable/renderers/CellRenderer.tsx
+++ b/src/components/_internal/BaseTable/renderers/CellRenderer.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+import type { CellRendererProps } from './renderers.types';
+
 import PropTypes from 'prop-types';
 import { isNotUndefined } from 'ramda-adjunct';
 
 import LinkRenderer from './LinkRenderer';
 import MultiValueRenderer from './MultiValueRenderer';
 import TooltipWrapper from '../components/TooltipWrapper';
-import { CellRendererProps } from './renderers.types';
 import { CellTypes } from './renderers.enums';
 
 function CellRenderer<D extends Record<string, unknown>>({
@@ -23,7 +24,7 @@ function CellRenderer<D extends Record<string, unknown>>({
     multiValueDisplayLimit,
   },
   row: { original: rowData },
-}: CellRendererProps<D>): React.ReactElement {
+}: CellRendererProps<D>): ReactElement {
   const cellValue = isNotUndefined(cellFormatter)
     ? cellFormatter(value, rowData)
     : value;

--- a/src/components/_internal/BaseTable/renderers/LinkRenderer.test.tsx
+++ b/src/components/_internal/BaseTable/renderers/LinkRenderer.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { noop } from 'ramda-adjunct';
 

--- a/src/components/_internal/BaseTable/renderers/LinkRenderer.tsx
+++ b/src/components/_internal/BaseTable/renderers/LinkRenderer.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+import type { LinkRendererProps } from './renderers.types';
+
 import cls from 'classnames';
 import { isNotUndefined, isUndefined, noop } from 'ramda-adjunct';
 
-import { LinkRendererProps } from './renderers.types';
 import { useLogger } from '../../../../hooks/useLogger';
 
 function LinkRenderer<D extends Record<string, unknown>>({
@@ -14,7 +15,7 @@ function LinkRenderer<D extends Record<string, unknown>>({
   component,
   rowData,
   className,
-}: LinkRendererProps<D>): React.ReactElement {
+}: LinkRendererProps<D>): ReactElement {
   const { error } = useLogger('LinkRenderer');
   const isRelativeLink = isNotUndefined(toComposer);
   if (isRelativeLink && isUndefined(component)) {

--- a/src/components/_internal/BaseTable/renderers/MultiValueRenderer.test.tsx
+++ b/src/components/_internal/BaseTable/renderers/MultiValueRenderer.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { identity, join, pipe, slice } from 'ramda';
 

--- a/src/components/_internal/BaseTable/renderers/MultiValueRenderer.tsx
+++ b/src/components/_internal/BaseTable/renderers/MultiValueRenderer.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+import type { MultiValueRendererProps } from './renderers.types';
+
 import { any, identity, map, pipe, slice } from 'ramda';
 import { isNotUndefined } from 'ramda-adjunct';
 
 import { Tooltip } from '../../../Tooltip';
 import LinkRenderer from './LinkRenderer';
 import TooltipWrapper from '../components/TooltipWrapper';
-import { MultiValueRendererProps } from './renderers.types';
 
 const renderRestValue = (startIndex, formatter, values) =>
   pipe(
@@ -28,7 +29,7 @@ function MultiValueRenderer<D extends Record<string, unknown>>({
   linkComponent,
   rowData,
   tooltipComposer,
-}: MultiValueRendererProps<D>): React.ReactElement {
+}: MultiValueRendererProps<D>): ReactElement {
   const hasDisplayLimit = multiValueDisplayLimit > 0;
   const valuesLength = values.length;
   const containsLink = any(isNotUndefined, [hrefComposer, toComposer, onClick]);

--- a/src/components/_internal/BaseTable/renderers/renderers.stories.tsx
+++ b/src/components/_internal/BaseTable/renderers/renderers.stories.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { Row } from 'react-table';
+import type { FC } from 'react';
+import type { CellRendererProps } from './renderers.types';
+
 import PropTypes from 'prop-types';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import { Row } from 'react-table';
 import { MemoryRouter } from 'react-router-dom';
 import { equals, F as stubFalse } from 'ramda';
 import { action } from '@storybook/addon-actions';
@@ -9,7 +11,6 @@ import { action } from '@storybook/addon-actions';
 import { composeQuery } from '../mocks/columns';
 import { BaseTableContainer, StyledBaseTable } from '../BaseTable.styles';
 import CellRenderer from './CellRenderer';
-import { CellRendererProps } from './renderers.types';
 import { CellTypes } from './renderers.enums';
 import { abbreviateNumber } from '../../../../utils';
 
@@ -45,7 +46,7 @@ type CellRendererData = {
   column2: string[];
 };
 
-const LinkComponent: React.FC<{ to: string; className: string }> = ({
+const LinkComponent: FC<{ to: string; className: string }> = ({
   to,
   children,
   className,

--- a/src/components/_internal/BaseTable/renderers/renderers.types.ts
+++ b/src/components/_internal/BaseTable/renderers/renderers.types.ts
@@ -1,8 +1,7 @@
 import type { CellValue, Row } from 'react-table';
 import type { To } from 'history';
 import type { ReactComponentLike } from 'prop-types';
-
-import { CellTypes as CellTypesEnum } from './renderers.enums';
+import type { CellTypes as CellTypesEnum } from './renderers.enums';
 
 type OnClickFn<D> = (value: CellValue, rowData: D) => void;
 type HrefComposerFn<D> = (value: CellValue, rowData: D) => string;

--- a/src/components/_internal/BaseTabs/BaseTabLabel.tsx
+++ b/src/components/_internal/BaseTabs/BaseTabLabel.tsx
@@ -1,3 +1,5 @@
+import type { BaseLabelProps } from './BaseTabLabel.types';
+
 import styled, { css } from 'styled-components';
 import { setLightness } from 'polished';
 import { __, includes, pipe, subtract } from 'ramda';
@@ -9,7 +11,6 @@ import {
   getToken,
   pxToRem,
 } from '../../../utils';
-import { BaseLabelProps } from './BaseTabLabel.types';
 import { BaseTabVariants } from './BaseTabs.enums';
 import { Padbox } from '../../layout/Padbox';
 

--- a/src/components/_internal/BaseTabs/BaseTabLabel.types.ts
+++ b/src/components/_internal/BaseTabs/BaseTabLabel.types.ts
@@ -1,8 +1,7 @@
-import { DefaultTheme } from 'styled-components';
-
-import { Color } from '../../../theme/colors.types';
-import { PadboxProps } from '../../layout/Padbox/Padbox';
-import { BaseTabVariants } from './BaseTabs.enums';
+import type { DefaultTheme } from 'styled-components';
+import type { Color } from '../../../theme/colors.types';
+import type { PadboxProps } from '../../layout/Padbox/Padbox';
+import type { BaseTabVariants } from './BaseTabs.enums';
 
 export type Variants = typeof BaseTabVariants[keyof typeof BaseTabVariants];
 

--- a/src/components/_internal/BaseTabs/BaseTabsWrapper.tsx
+++ b/src/components/_internal/BaseTabs/BaseTabsWrapper.tsx
@@ -1,8 +1,9 @@
+import type { Variants } from './BaseTabLabel.types';
+
 import styled, { css } from 'styled-components';
 
 import { Padbox } from '../../layout';
 import { getColor, getRadii } from '../../../utils';
-import { Variants } from './BaseTabLabel.types';
 import { BaseTabVariants } from './BaseTabs.enums';
 
 export const BaseTabsWrapper = styled(Padbox)<{

--- a/src/components/_internal/BaseToastBanner/BaseToastBanner.tsx
+++ b/src/components/_internal/BaseToastBanner/BaseToastBanner.tsx
@@ -1,4 +1,9 @@
-import React from 'react';
+import type { FC } from 'react';
+import type {
+  BaseToastBannerProps,
+  BaseToastBannerWrapperProps,
+} from './BaseToastBanner.types';
+
 import styled from 'styled-components';
 import { isNotNilOrEmpty } from 'ramda-adjunct';
 
@@ -9,10 +14,6 @@ import { ColorTypes } from '../../../theme/colors.enums';
 import { Padbox } from '../../layout/Padbox';
 import { Inline } from '../../layout/Inline';
 import { Icon } from '../../Icon';
-import {
-  BaseToastBannerProps,
-  BaseToastBannerWrapperProps,
-} from './BaseToastBanner.types';
 
 export const baseToastBannerColorVariants = {
   [BaseToastBannerVariants.info]: ColorTypes.info50,
@@ -63,7 +64,7 @@ const StyledIcon = styled(Icon)<{
     pxToRem($iconPxSizesVariants[$variant])};
 `;
 
-const BaseToastBanner: React.FC<BaseToastBannerWrapperProps> = ({
+const BaseToastBanner: FC<BaseToastBannerWrapperProps> = ({
   children,
   variant,
   paddingSize,

--- a/src/components/_internal/BaseToastBanner/BaseToastBanner.types.ts
+++ b/src/components/_internal/BaseToastBanner/BaseToastBanner.types.ts
@@ -1,14 +1,13 @@
-import React from 'react';
-
-import { InlineProps } from '../../layout/Inline/Inline';
-import { PadboxProps } from '../../layout/Padbox/Padbox';
-import { BaseToastBannerVariants } from './BaseToastBanner.enums';
+import type { MouseEventHandler, ReactNode } from 'react';
+import type { InlineProps } from '../../layout/Inline/Inline';
+import type { PadboxProps } from '../../layout/Padbox/Padbox';
+import type { BaseToastBannerVariants } from './BaseToastBanner.enums';
 
 export type Variants =
   typeof BaseToastBannerVariants[keyof typeof BaseToastBannerVariants];
 
 export interface BaseToastBannerWrapperProps {
-  children: React.ReactNode;
+  children: ReactNode;
   variant: Variants;
   paddingSize: PadboxProps['paddingSize'];
   paddingType: PadboxProps['paddingType'];
@@ -19,6 +18,6 @@ export interface BaseToastBannerWrapperProps {
 }
 
 export interface BaseToastBannerProps {
-  onClose: React.MouseEventHandler;
+  onClose: MouseEventHandler;
   variant?: Variants;
 }

--- a/src/components/forms/Checkbox/Checkbox.stories.tsx
+++ b/src/components/forms/Checkbox/Checkbox.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { CheckboxProps } from './Checkbox.types';
+
 import { action } from '@storybook/addon-actions';
 
 import Checkbox from './Checkbox';
-import { CheckboxProps } from './Checkbox.types';
 import { Inline } from '../../layout';
 import { Icon } from '../../Icon';
 import { Text } from '../../typographyLegacy/Text';

--- a/src/components/forms/Checkbox/Checkbox.tsx
+++ b/src/components/forms/Checkbox/Checkbox.tsx
@@ -1,4 +1,8 @@
-import React, { forwardRef } from 'react';
+import type { HTMLProps } from 'react';
+import type { TogglingInputProps } from '../types/forms.types';
+import type { CheckboxProps } from './Checkbox.types';
+
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { add, identity, memoizeWith, pipe } from 'ramda';
@@ -9,8 +13,6 @@ import * as checked from '../../../theme/icons/check';
 import * as indeterminate from '../../../theme/icons/minus';
 import { getColor, getFormStyle, getRadii, pxToRem } from '../../../utils';
 import { Label } from '../Label';
-import { TogglingInputProps } from '../types/forms.types';
-import { CheckboxProps } from './Checkbox.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
 const CheckboxWrapper = styled.div`
@@ -106,7 +108,7 @@ const getLabelStyles = css`
   margin-left: ${({ theme }) => `-${getRemToggleSize({ theme })}`};
 `;
 
-const CheckboxLabel = styled(Label)<React.HTMLProps<HTMLLabelElement>>`
+const CheckboxLabel = styled(Label)<HTMLProps<HTMLLabelElement>>`
   display: flex;
   align-items: center;
   padding-top: 0;

--- a/src/components/forms/Checkbox/Checkbox.types.ts
+++ b/src/components/forms/Checkbox/Checkbox.types.ts
@@ -1,4 +1,4 @@
-import { TogglingProps } from '../types/forms.types';
+import type { TogglingProps } from '../types/forms.types';
 
 export interface CheckboxProps extends TogglingProps {
   checkboxId?: string;

--- a/src/components/forms/Input/Input.stories.tsx
+++ b/src/components/forms/Input/Input.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { InputHTMLAttributes } from 'react';
+import type { InputProps } from './Input.types';
 
 import Input from './Input';
-import { InputProps } from './Input.types';
 
 export default {
   title: 'components/forms/Input',
@@ -30,7 +30,7 @@ export default {
 } as Meta;
 
 export const Playground: Story<
-  InputProps & React.InputHTMLAttributes<HTMLInputElement>
+  InputProps & InputHTMLAttributes<HTMLInputElement>
 > = (args) => <Input {...args} aria-label="Input" />;
 Playground.args = { type: 'text' };
 Playground.parameters = {

--- a/src/components/forms/Input/Input.tsx
+++ b/src/components/forms/Input/Input.tsx
@@ -1,3 +1,5 @@
+import type { InputProps } from './Input.types';
+
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 
@@ -8,7 +10,6 @@ import {
   getFormStyle,
   getRadii,
 } from '../../../utils';
-import { InputProps } from './Input.types';
 import { SpaceSizes } from '../../../theme';
 import { PaddingTypes } from '../../layout/Padbox/Padbox.enums';
 import { CLX_COMPONENT } from '../../../theme/constants';

--- a/src/components/forms/Input/Input.types.ts
+++ b/src/components/forms/Input/Input.types.ts
@@ -1,7 +1,7 @@
-import React from 'react';
+import type { ComponentPropsWithoutRef } from 'react';
 
 export interface InputProps
-  extends Omit<React.ComponentPropsWithRef<'input'>, 'disabled'> {
+  extends Omit<ComponentPropsWithoutRef<'input'>, 'disabled'> {
   isInvalid?: boolean;
   isDisabled?: boolean;
   [key: string]: unknown;

--- a/src/components/forms/InputGroup/InputGroup.stories.tsx
+++ b/src/components/forms/InputGroup/InputGroup.stories.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 
 import InputGroup from './InputGroup';
 import { Input, Password, Select } from '..';

--- a/src/components/forms/InputGroup/InputGroup.tsx
+++ b/src/components/forms/InputGroup/InputGroup.tsx
@@ -1,8 +1,12 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { InputGroupProps } from './InputGroup.types';
+import type { InlineProps } from '../../layout/Inline/Inline';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { prop } from 'ramda';
 import cls from 'classnames';
+import { Children } from 'react';
 
 import { getFormStyle, getRadii } from '../../../utils';
 import { Input } from '../Input';
@@ -10,8 +14,6 @@ import { Password } from '../Password';
 import { Select } from '../Select';
 import { Icon } from '../../Icon';
 import { Inline, Padbox } from '../../layout';
-import { InputGroupProps } from './InputGroup.types';
-import { InlineProps } from '../../layout/Inline/Inline';
 import { Button } from '../../Button';
 import { SearchBar } from '../SearchBar';
 import { CLX_COMPONENT } from '../../../theme/constants';
@@ -58,7 +60,7 @@ const IconContainer = styled(Padbox)`
   align-items: center;
 `;
 
-const InputGroup: React.FC<InputGroupProps & InlineProps> = ({
+const InputGroup: FC<InputGroupProps & InlineProps> = ({
   children,
   hasDivider,
   className,
@@ -74,7 +76,7 @@ const InputGroup: React.FC<InputGroupProps & InlineProps> = ({
     InputGroup,
     SearchBar,
   ];
-  React.Children.forEach(children, (child) => {
+  Children.forEach(children, (child) => {
     if (!ALLOWED_CHILDREN.includes(prop('type', child))) {
       error(
         'Only Select, Input, InputGroup, Icon, Button, SearchBar and Password are valid childs of InputGroup',
@@ -88,7 +90,7 @@ const InputGroup: React.FC<InputGroupProps & InlineProps> = ({
       {...inlineProps}
       stretch={inlineProps.stretch || 'start'}
     >
-      {React.Children.map(children, (child) => {
+      {Children.map(children, (child) => {
         if (prop('type', child) === Icon) {
           return <IconContainer paddingSize="sm">{child}</IconContainer>;
         }

--- a/src/components/forms/InputGroup/InputGroup.types.ts
+++ b/src/components/forms/InputGroup/InputGroup.types.ts
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 
 export type InputGroupProps = PropsWithChildren<{
   hasDivider?: boolean;

--- a/src/components/forms/Label/Label.stories.tsx
+++ b/src/components/forms/Label/Label.stories.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
 
 import Label from './Label';
 

--- a/src/components/forms/Label/Label.tsx
+++ b/src/components/forms/Label/Label.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ComponentPropsWithRef, FC, HTMLProps } from 'react';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import cls from 'classnames';
@@ -20,8 +21,8 @@ const LabelContainer = styled(Text)`
   }
 `;
 
-const Label: React.FC<
-  React.HTMLProps<HTMLLabelElement> & React.ComponentProps<typeof Text>
+const Label: FC<
+  HTMLProps<HTMLLabelElement> & ComponentPropsWithRef<typeof Text>
 > = ({ children, htmlFor, className, ...props }) => (
   <LabelContainer
     as="label"

--- a/src/components/forms/Message/Message.stories.tsx
+++ b/src/components/forms/Message/Message.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ReactChild } from 'react';
+import type { MessageProps } from './Message.types';
 
 import Message, { Error, Note } from './Message';
-import { MessageProps } from './Message.types';
 import { MessageVariants } from './Message.enums';
 import { generateControl } from '../../../utils/tests/storybook';
 
@@ -22,9 +22,9 @@ export default {
   },
 } as Meta;
 
-export const Playground: Story<
-  MessageProps & { children: React.ReactChild }
-> = (args) => <Message {...args} />;
+export const Playground: Story<MessageProps & { children: ReactChild }> = (
+  args,
+) => <Message {...args} />;
 Playground.args = {
   children: 'Form field message',
   variant: MessageVariants.note,

--- a/src/components/forms/Message/Message.tsx
+++ b/src/components/forms/Message/Message.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { MessageProps } from './Message.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -7,7 +9,6 @@ import { getSpace } from '../../../utils';
 import { Paragraph } from '../../typographyLegacy';
 import { TextSizes } from '../../typographyLegacy/Text/Text.enums';
 import { MessageVariants } from './Message.enums';
-import { MessageProps } from './Message.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
 const MessageContainer = styled.div`
@@ -19,7 +20,7 @@ const MessageContainer = styled.div`
   }
 `;
 
-const Message: React.FC<MessageProps> = ({
+const Message: FC<MessageProps> = ({
   children,
   variant = MessageVariants.note,
 }) => (
@@ -36,9 +37,9 @@ Message.propTypes = {
 
 export default Message;
 
-export const Note: React.FC = ({ children }) => (
+export const Note: FC = ({ children }) => (
   <Message variant={MessageVariants.note}>{children}</Message>
 );
-export const Error: React.FC = ({ children }) => (
+export const Error: FC = ({ children }) => (
   <Message variant={MessageVariants.error}>{children}</Message>
 );

--- a/src/components/forms/Message/Message.types.ts
+++ b/src/components/forms/Message/Message.types.ts
@@ -1,4 +1,4 @@
-import { MessageVariants } from './Message.enums';
+import type { MessageVariants } from './Message.enums';
 
 export type Variants = typeof MessageVariants[keyof typeof MessageVariants];
 

--- a/src/components/forms/MultiValueInput/MultiValueInput.stories.tsx
+++ b/src/components/forms/MultiValueInput/MultiValueInput.stories.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { MultiValueInputProps } from './MultiValueInput.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 import { noop } from 'ramda-adjunct';
 
 import MultiValueInput from './MultiValueInput';
 import { Label } from '../Label';
-import { MultiValueInputProps } from './MultiValueInput.types';
 import { Heading, Strong } from '../../typographyLegacy';
 import { Inline, Stack } from '../../layout';
 import { Button } from '../../Button';

--- a/src/components/forms/MultiValueInput/MultiValueInput.test.tsx
+++ b/src/components/forms/MultiValueInput/MultiValueInput.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/components/forms/MultiValueInput/MultiValueInput.tsx
+++ b/src/components/forms/MultiValueInput/MultiValueInput.tsx
@@ -1,4 +1,16 @@
-import React, { useState } from 'react';
+import type {
+  ChangeEventHandler,
+  ClipboardEventHandler,
+  FC,
+  KeyboardEventHandler,
+  MouseEventHandler,
+} from 'react';
+import type {
+  MultiValueInputProps,
+  ValueContainerProps,
+} from './MultiValueInput.types';
+
+import { useState } from 'react';
 import styled, { css } from 'styled-components';
 import AutosizeInput from 'react-input-autosize';
 import PropTypes from 'prop-types';
@@ -23,7 +35,6 @@ import {
   omitIndexes,
 } from 'ramda-adjunct';
 import { useDeepCompareEffect } from 'use-deep-compare';
-import 'focus-within-polyfill';
 import cls from 'classnames';
 
 import {
@@ -40,11 +51,9 @@ import { Icon } from '../../Icon';
 import { SSCIconNames } from '../../../theme/icons/icons.enums';
 import { PaddingTypes } from '../../layout/Padbox/Padbox.enums';
 import { Pill } from '../../Pill';
-import {
-  MultiValueInputProps,
-  ValueContainerProps,
-} from './MultiValueInput.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
+
+import 'focus-within-polyfill';
 
 const getBorderStyle = (width, color) => css`
   box-shadow: inset 0 0 0 ${getFormStyle(width)} ${getFormStyle(color)};
@@ -118,7 +127,7 @@ const ClearButton = styled(Padbox)`
   }
 `;
 
-const MultiValueInput: React.FC<MultiValueInputProps> = ({
+const MultiValueInput: FC<MultiValueInputProps> = ({
   value = [],
   isInvalid = false,
   isDisabled = false,
@@ -185,9 +194,7 @@ const MultiValueInput: React.FC<MultiValueInputProps> = ({
     setValues(value);
   }, [value, setValues]);
 
-  const handleInputOnKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (
-    e,
-  ) => {
+  const handleInputOnKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
     switch (e.key) {
       case ';':
       case 'Enter':
@@ -209,9 +216,7 @@ const MultiValueInput: React.FC<MultiValueInputProps> = ({
     }
   };
 
-  const handleInputOnPaste: React.ClipboardEventHandler<HTMLInputElement> = (
-    e,
-  ) => {
+  const handleInputOnPaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
     e.preventDefault();
     const pastedValue = (e.clipboardData || window.clipboardData).getData(
       'text',
@@ -219,16 +224,12 @@ const MultiValueInput: React.FC<MultiValueInputProps> = ({
     addValue(pastedValue);
   };
 
-  const handleInputOnChange: React.ChangeEventHandler<HTMLInputElement> = (
-    e,
-  ) => {
+  const handleInputOnChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     onInputChange(e);
     setInputValue(e.target.value);
   };
 
-  const handleContainerOnClick: React.MouseEventHandler<HTMLDivElement> = (
-    e,
-  ) => {
+  const handleContainerOnClick: MouseEventHandler<HTMLDivElement> = (e) => {
     e.preventDefault();
     if (isNotNull(inputRef)) {
       inputRef.focus();
@@ -240,9 +241,9 @@ const MultiValueInput: React.FC<MultiValueInputProps> = ({
     onValueRemove([]);
     onValuesChange([]);
   };
-  const handleClearAllOnKeyDown: React.KeyboardEventHandler<
-    HTMLInputElement
-  > = (e) => {
+  const handleClearAllOnKeyDown: KeyboardEventHandler<HTMLInputElement> = (
+    e,
+  ) => {
     switch (e.key) {
       case ' ':
       case 'Enter':

--- a/src/components/forms/MultiValueInput/MultiValueInput.types.ts
+++ b/src/components/forms/MultiValueInput/MultiValueInput.types.ts
@@ -1,6 +1,5 @@
-import React from 'react';
-
-import { PadboxProps } from '../../layout/Padbox/Padbox';
+import type { ChangeEvent, InputHTMLAttributes } from 'react';
+import type { PadboxProps } from '../../layout/Padbox/Padbox';
 
 export interface ValueContainerProps extends PadboxProps {
   $isInvalid: boolean;
@@ -19,7 +18,7 @@ export interface MultiValueProps {
 }
 
 export interface MultiValueInputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+  extends InputHTMLAttributes<HTMLInputElement> {
   value?: Array<MultiValueProps['label']>;
   isInvalid?: ValueContainerProps['$isInvalid'];
   isDisabled?: ValueContainerProps['$isDisabled'];
@@ -35,5 +34,5 @@ export interface MultiValueInputProps
   ) => void;
   onValueRemove?: (nextValues: MultiValueInputProps['value']) => void;
   onValuesChange?: (nextValues: MultiValueInputProps['value']) => void;
-  onInputChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onInputChange?: (event: ChangeEvent<HTMLInputElement>) => void;
 }

--- a/src/components/forms/Password/Password.stories.tsx
+++ b/src/components/forms/Password/Password.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { PasswordProps } from './Password.types';
 
 import Password from './Password';
-import { PasswordProps } from './Password.types';
 
 export default {
   title: 'components/forms/Password',

--- a/src/components/forms/Password/Password.tsx
+++ b/src/components/forms/Password/Password.tsx
@@ -1,4 +1,7 @@
-import React, { useState } from 'react';
+import type { FC } from 'react';
+import type { PasswordProps } from './Password.types';
+
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import cls from 'classnames';
@@ -7,7 +10,6 @@ import { createPadding, getSpace, pxToRem } from '../../../utils';
 import { Icon } from '../../Icon';
 import { IconTypes, SSCIconNames } from '../../../theme/icons/icons.enums';
 import { Input } from '../Input';
-import { PasswordProps } from './Password.types';
 import { ColorTypes, SpaceSizes } from '../../../theme';
 import { PaddingTypes } from '../../layout/Padbox/Padbox.enums';
 import { CLX_COMPONENT } from '../../../theme/constants';
@@ -40,7 +42,7 @@ const ToggleButton = styled.button`
   justify-content: center;
 `;
 
-const Password: React.FC<PasswordProps> = ({
+const Password: FC<PasswordProps> = ({
   isInvalid = false,
   isDisabled = false,
   defaultIsRevealed = false,

--- a/src/components/forms/Password/Password.types.ts
+++ b/src/components/forms/Password/Password.types.ts
@@ -1,8 +1,9 @@
-import { InputProps } from '../Input/Input.types';
+import type { InputHTMLAttributes } from 'react';
+import type { InputProps } from '../Input/Input.types';
 
 export interface PasswordProps
   extends InputProps,
-    React.InputHTMLAttributes<HTMLInputElement> {
+    InputHTMLAttributes<HTMLInputElement> {
   defaultIsRevealed?: boolean;
   className?: string;
 }

--- a/src/components/forms/Radio/Radio.stories.tsx
+++ b/src/components/forms/Radio/Radio.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { RadioProps } from './Radio.types';
+
 import { action } from '@storybook/addon-actions';
 
 import Radio from './Radio';
-import { RadioProps } from './Radio.types';
 import { ColorTypes } from '../../../theme';
 import { Inline } from '../../layout';
 import { Icon } from '../../Icon';

--- a/src/components/forms/Radio/Radio.tsx
+++ b/src/components/forms/Radio/Radio.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+import type { FC, HTMLProps } from 'react';
+import type { TogglingInputProps } from '../types/forms.types';
+import type { RadioProps } from './Radio.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { isNotUndefined } from 'ramda-adjunct';
@@ -6,12 +9,10 @@ import cls from 'classnames';
 
 import { getFormStyle, getRadii, pxToRem } from '../../../utils';
 import { Label } from '../Label';
-import { TogglingInputProps } from '../types/forms.types';
-import { RadioProps } from './Radio.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
 const RadioLabel = styled(Label)<
-  React.HTMLProps<HTMLLabelElement> & { hasLabel: boolean }
+  HTMLProps<HTMLLabelElement> & { hasLabel: boolean }
 >`
   position: relative;
   display: flex;
@@ -90,7 +91,7 @@ const RadioInput = styled.input<TogglingInputProps>`
     `}
 `;
 
-const Radio: React.FC<RadioProps> = ({
+const Radio: FC<RadioProps> = ({
   name,
   radioId,
   label,

--- a/src/components/forms/Radio/Radio.types.ts
+++ b/src/components/forms/Radio/Radio.types.ts
@@ -1,4 +1,4 @@
-import { TogglingProps } from '../types/forms.types';
+import type { TogglingProps } from '../types/forms.types';
 
 export interface RadioProps extends Omit<TogglingProps, 'isIndeterminate'> {
   radioId: string;

--- a/src/components/forms/Range/Range.stories.tsx
+++ b/src/components/forms/Range/Range.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { InputHTMLAttributes } from 'react';
+import type { RangeProps } from './Range.types';
 
 import Range from './Range';
-import { RangeProps } from './Range.types';
 
 export default {
   title: 'components/forms/Range',
@@ -10,7 +10,7 @@ export default {
 } as Meta;
 
 const RangeTemplate: Story<
-  RangeProps & React.InputHTMLAttributes<HTMLInputElement>
+  RangeProps & InputHTMLAttributes<HTMLInputElement>
 > = (args) => <Range {...args} aria-label="Input" />;
 
 export const Playground = RangeTemplate.bind({});

--- a/src/components/forms/Range/Range.tsx
+++ b/src/components/forms/Range/Range.tsx
@@ -1,4 +1,7 @@
-import React, { forwardRef, useState } from 'react';
+import type { ChangeEventHandler } from 'react';
+import type { RangeInputProps, RangeProps } from './Range.types';
+
+import { forwardRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import { noop } from 'ramda-adjunct';
@@ -7,7 +10,6 @@ import cls from 'classnames';
 import { getFormStyle, pxToRem } from '../../../utils';
 import { Text } from '../../typographyLegacy';
 import { Inline, Stack } from '../../layout';
-import { RangeInputProps, RangeProps } from './Range.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
 const RangeWrapper = styled.div`
@@ -172,7 +174,7 @@ const Range = forwardRef<HTMLInputElement, RangeProps>(
       defaultValue ?? (min + max) / 2,
     );
 
-    const handleOnChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    const handleOnChange: ChangeEventHandler<HTMLInputElement> = (e) => {
       setRangeValue(parseInt(e.target.value, 10));
       onChange(e);
     };

--- a/src/components/forms/Range/Range.types.ts
+++ b/src/components/forms/Range/Range.types.ts
@@ -1,5 +1,6 @@
-export interface RangeProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+import type { InputHTMLAttributes } from 'react';
+
+export interface RangeProps extends InputHTMLAttributes<HTMLInputElement> {
   /**
    * Element id to retreive value by external components
    */
@@ -33,8 +34,7 @@ export interface RangeProps
   step?: number;
   className?: string;
 }
-export interface RangeInputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface RangeInputProps extends InputHTMLAttributes<HTMLInputElement> {
   isInvalid?: boolean;
   isDisabled?: boolean;
   isProgressRight?: boolean;

--- a/src/components/forms/SearchBar/SearchBar.stories.tsx
+++ b/src/components/forms/SearchBar/SearchBar.stories.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SearchBarProps } from './SearchBar.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import { Inline, Stack } from '../../layout';
 import { Button } from '../../Button';
 import SearchBar from './SearchBar';
-import { SearchBarProps } from './SearchBar.types';
 
 export default {
   title: 'components/forms/SearchBar',

--- a/src/components/forms/SearchBar/SearchBar.tsx
+++ b/src/components/forms/SearchBar/SearchBar.tsx
@@ -1,4 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import type { ChangeEventHandler, KeyboardEventHandler } from 'react';
+import type { SearchBarProps } from './SearchBar.types';
+
+import { forwardRef, useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import {
   isNonEmptyString,
@@ -16,7 +19,6 @@ import { Icon } from '../../Icon';
 import { IconTypes, SSCIconNames } from '../../../theme/icons/icons.enums';
 import { Spinner } from '../../Spinner';
 import { useField } from './useField';
-import { SearchBarProps } from './SearchBar.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
 const SearchBarRoot = styled.div`
@@ -69,7 +71,7 @@ const SearchInput = styled(Input)`
     getSpace($isClearable ? SpaceSizes.lgPlus : SpaceSizes.md, { theme })};
 `;
 
-const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
+const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
   (
     {
       value: valueFromProps,
@@ -132,7 +134,7 @@ const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const handleOnChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    const handleOnChange: ChangeEventHandler<HTMLInputElement> = (e) => {
       const eventValue = e.target.value;
       if (hasDebouncedSearch) {
         if (typingTimeout) {
@@ -146,7 +148,7 @@ const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
       }
       onChange(e);
     };
-    const handleOnKeyUp: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    const handleOnKeyUp: KeyboardEventHandler<HTMLInputElement> = (e) => {
       if (isNotUndefined(onKeyUp)) {
         onKeyUp(e);
       }

--- a/src/components/forms/SearchBar/SearchBar.types.ts
+++ b/src/components/forms/SearchBar/SearchBar.types.ts
@@ -1,3 +1,5 @@
+import type { ChangeEventHandler, ComponentPropsWithRef } from 'react';
+
 type WithDebouncedSearch = {
   /**
    * If true search is triggered automatically by onChange event.
@@ -24,7 +26,7 @@ type ControlledSearchInputProps = {
   /**
    * Change event
    */
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
+  onChange: ChangeEventHandler<HTMLInputElement>;
   /**
    * Default value for uncontrolled form component
    */
@@ -33,7 +35,7 @@ type ControlledSearchInputProps = {
 
 type UncontrolledSearchInputProps = {
   value?: never;
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
   defaultValue?: string;
 } & DebounceProps;
 
@@ -41,7 +43,7 @@ export type SearchBarProps = (
   | ControlledSearchInputProps
   | UncontrolledSearchInputProps
 ) &
-  Omit<React.ComponentPropsWithRef<'input'>, 'disabled'> & {
+  Omit<ComponentPropsWithRef<'input'>, 'disabled'> & {
     /**
      * Event triggered by clicking clear button. For controlled component
      * should reset the `value` property. For uncontrolled component

--- a/src/components/forms/SegmentedToggle/SegmentedToggle.stories.tsx
+++ b/src/components/forms/SegmentedToggle/SegmentedToggle.stories.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SegmentedToggleProps } from './SegmentedToggle.types';
 
-import { SegmentedToggleProps } from './SegmentedToggle.types';
+import { useState } from 'react';
+
 import { SegmentedToggle, SegmentedToggleItem } from './index';
 import { SpaceSizes } from '../../../theme/space.enums';
 import { Stack } from '../../layout/Stack';

--- a/src/components/forms/SegmentedToggle/SegmentedToggle.test.tsx
+++ b/src/components/forms/SegmentedToggle/SegmentedToggle.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import { createRef } from 'react';
 import { screen } from '@testing-library/react';
 import { map } from 'ramda';
 

--- a/src/components/forms/SegmentedToggle/SegmentedToggle.tsx
+++ b/src/components/forms/SegmentedToggle/SegmentedToggle.tsx
@@ -1,12 +1,14 @@
-import PropTypes from 'prop-types';
-import React, { forwardRef } from 'react';
-import { noop } from 'ramda-adjunct';
-import cls from 'classnames';
-
+import type { PropsWithChildren, ReactElement } from 'react';
 import type {
   SegmentedToggleItemProps,
   SegmentedToggleProps,
 } from './SegmentedToggle.types';
+
+import PropTypes from 'prop-types';
+import { Children, cloneElement, forwardRef, isValidElement } from 'react';
+import { noop } from 'ramda-adjunct';
+import cls from 'classnames';
+
 import { BaseTabsWrapper } from '../../_internal/BaseTabs/BaseTabsWrapper';
 import { SpaceSizes } from '../../../theme/space.enums';
 import { Inline } from '../../layout';
@@ -15,7 +17,7 @@ import { CLX_COMPONENT } from '../../../theme/constants';
 
 const SegmentedToggle = forwardRef<
   HTMLDivElement,
-  React.PropsWithChildren<SegmentedToggleProps>
+  PropsWithChildren<SegmentedToggleProps>
 >(
   (
     {
@@ -35,13 +37,13 @@ const SegmentedToggle = forwardRef<
       paddingSize={SpaceSizes.xs}
     >
       <Inline gap={SpaceSizes.sm} role="radiogroup">
-        {React.Children.map(children, (segmentedToggleItem) => {
-          if (!React.isValidElement(segmentedToggleItem)) {
+        {Children.map(children, (segmentedToggleItem) => {
+          if (!isValidElement(segmentedToggleItem)) {
             return null;
           }
 
-          return React.cloneElement(
-            segmentedToggleItem as React.ReactElement<SegmentedToggleItemProps>,
+          return cloneElement(
+            segmentedToggleItem as ReactElement<SegmentedToggleItemProps>,
             {
               key: segmentedToggleItem.props.value,
               name: group,

--- a/src/components/forms/SegmentedToggle/SegmentedToggle.types.ts
+++ b/src/components/forms/SegmentedToggle/SegmentedToggle.types.ts
@@ -1,9 +1,13 @@
-import React from 'react';
+import type {
+  ChangeEventHandler,
+  ComponentPropsWithoutRef,
+  ReactText,
+} from 'react';
 
 export interface SegmentedToggleItemProps
-  extends Omit<React.ComponentPropsWithoutRef<'input'>, 'size'> {
+  extends Omit<ComponentPropsWithoutRef<'input'>, 'size'> {
   label: string;
-  value: React.ReactText;
+  value: ReactText;
   itemId: string;
   group?: string;
 }
@@ -21,6 +25,6 @@ export interface SegmentedToggleProps {
   /**
    * Callback when the SegmentedToggle has changed
    */
-  onChange?: React.ChangeEventHandler;
+  onChange?: ChangeEventHandler;
   className?: string;
 }

--- a/src/components/forms/SegmentedToggle/SegmentedToggleItem.tsx
+++ b/src/components/forms/SegmentedToggle/SegmentedToggleItem.tsx
@@ -1,8 +1,9 @@
-import React, { forwardRef } from 'react';
+import type { SegmentedToggleItemProps } from './SegmentedToggle.types';
+
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { SegmentedToggleItemProps } from './SegmentedToggle.types';
 import { ColorTypes } from '../../../theme/colors.enums';
 import BaseTabLabel, {
   segmentedTabSelected,

--- a/src/components/forms/Select/CreatableSelect.stories.tsx
+++ b/src/components/forms/Select/CreatableSelect.stories.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
-import { isNull } from 'ramda-adjunct';
-import { GroupedOptionsType, OptionsType } from 'react-select';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { GroupedOptionsType, OptionsType } from 'react-select';
+import type { CreatableSelectProps, Option } from './Select.types';
 
-import { CreatableSelectProps, Option } from './Select.types';
+import { isNull } from 'ramda-adjunct';
+import { useState } from 'react';
+
 import CreatableSelect from './CreatableSelect';
 import { Stack } from '../../layout';
 

--- a/src/components/forms/Select/CreatableSelect.tsx
+++ b/src/components/forms/Select/CreatableSelect.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+import type { CreatableSelectProps } from './Select.types';
+
 import PropTypes from 'prop-types';
 import CreatableReactSelect from 'react-select/creatable';
 import AsyncCreatableReactSelect from 'react-select/async-creatable';
@@ -8,7 +10,6 @@ import { Strong } from '../../typographyLegacy';
 import { TextVariants } from '../../typographyLegacy/Text/Text.enums';
 import { useSelectProps } from './useSelectProps';
 import Select from './Select';
-import { CreatableSelectProps } from './Select.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
 const renderCreateLabel = (createNewLabel: string) => (inputValue: string) =>
@@ -22,7 +23,7 @@ function CreatableSelect<IsMulti extends boolean = false>({
   createNewLabel = 'Create',
   isAsync = false,
   ...props
-}: CreatableSelectProps<IsMulti>): React.ReactElement {
+}: CreatableSelectProps<IsMulti>): ReactElement {
   const selectProps = useSelectProps<IsMulti>(props);
 
   if (isAsync) {

--- a/src/components/forms/Select/Select.stories.tsx
+++ b/src/components/forms/Select/Select.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { Option, SelectProps } from './Select.types';
+
 import { action } from '@storybook/addon-actions';
 
 import Select from './Select';
-import { Option, SelectProps } from './Select.types';
 import { Inline, Stack } from '../../layout';
 import { Heading, Text } from '../../typographyLegacy';
 import { Pill } from '../../Pill';

--- a/src/components/forms/Select/Select.styles.tsx
+++ b/src/components/forms/Select/Select.styles.tsx
@@ -1,14 +1,18 @@
-import React, { ComponentType, useState } from 'react';
-import { transparentize } from 'polished';
-import { ThemeConfig } from 'react-select/src/theme';
-import {
+import type { ComponentType, MouseEventHandler } from 'react';
+import type { ThemeConfig } from 'react-select/src/theme';
+import type {
   IndicatorComponentType,
   IndicatorContainerProps,
   MenuProps,
   OptionProps,
   StylesConfig,
-  components,
 } from 'react-select';
+import type { DefaultTheme } from 'styled-components';
+import type { MenuActionArgs, Option as OptionType } from './Select.types';
+
+import { Children, useState } from 'react';
+import { transparentize } from 'polished';
+import { components } from 'react-select';
 import { append, apply, assoc, both, includes, pick, pipe, take } from 'ramda';
 import {
   isEmptyString,
@@ -16,7 +20,7 @@ import {
   isNotNilOrEmpty,
   isNotUndefined,
 } from 'ramda-adjunct';
-import styled, { DefaultTheme } from 'styled-components';
+import styled from 'styled-components';
 
 import { Checkbox } from '../Checkbox';
 import { IconTypes, SSCIconNames } from '../../../theme/icons/icons.enums';
@@ -25,7 +29,6 @@ import { ButtonVariants } from '../../Button/Button.enums';
 import { Cluster, Inline } from '../../layout';
 import { PaddingTypes } from '../../layout/Padbox/Padbox.enums';
 import { Icon } from '../../Icon';
-import { MenuActionArgs, Option as OptionType } from './Select.types';
 import { getPaddingSpace } from '../../../utils/space';
 import {
   createPadding,
@@ -286,9 +289,9 @@ export const ClearIndicator: IndicatorComponentType<OptionType, boolean> = (
 type InnerProps = {
   id: string;
   key: string;
-  onClick: React.MouseEventHandler<HTMLElement>;
-  onMouseMove: React.MouseEventHandler<HTMLElement>;
-  onMouseOver: React.MouseEventHandler<HTMLElement>;
+  onClick: MouseEventHandler<HTMLElement>;
+  onMouseMove: MouseEventHandler<HTMLElement>;
+  onMouseOver: MouseEventHandler<HTMLElement>;
   tabIndex: number;
 };
 export const MultiValueContainer: ComponentType<Record<string, unknown>> = ({
@@ -407,7 +410,7 @@ export const ValueContainer = (props) => {
   if (isMulti) {
     const qty = getValue().length;
     const [values, input] = children;
-    const selectedValues = React.Children.toArray(values);
+    const selectedValues = Children.toArray(values);
 
     const pills =
       isNotUndefined(maxVisibleItem) && !showAllItems && qty > maxVisibleItem

--- a/src/components/forms/Select/Select.tsx
+++ b/src/components/forms/Select/Select.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { ReactElement } from 'react';
+import type { SelectProps } from './Select.types';
+
 import ReactSelect from 'react-select';
 import AsyncReactSelect from 'react-select/async';
 import PropTypes from 'prop-types';
@@ -6,13 +8,13 @@ import cls from 'classnames';
 
 import { ActionKindsPropType } from '../../../types/action.types';
 import { useSelectProps } from './useSelectProps';
-import { GroupPropType, OptionPropType, SelectProps } from './Select.types';
+import { GroupPropType, OptionPropType } from './Select.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
 function Select<IsMulti extends boolean = false>({
   isAsync = false,
   ...props
-}: SelectProps<IsMulti>): React.ReactElement {
+}: SelectProps<IsMulti>): ReactElement {
   const selectProps = useSelectProps<IsMulti>(props);
   const { className } = props;
 

--- a/src/components/forms/Select/Select.types.ts
+++ b/src/components/forms/Select/Select.types.ts
@@ -1,10 +1,10 @@
-import { CommonProps, Props as ReactSelectProps } from 'react-select';
-import { Props as ReactSelectCreatableProps } from 'react-select/creatable';
-import { Props as ReactSelectAsyncProps } from 'react-select/async';
-import { Props as ReactSelectAsyncCreatableProps } from 'react-select/async-creatable';
-import PropTypes from 'prop-types';
+import type { CommonProps, Props as ReactSelectProps } from 'react-select';
+import type { Props as ReactSelectCreatableProps } from 'react-select/creatable';
+import type { Props as ReactSelectAsyncProps } from 'react-select/async';
+import type { Props as ReactSelectAsyncCreatableProps } from 'react-select/async-creatable';
+import type { ActionKinds } from '../../../types/action.types';
 
-import { ActionKinds } from '../../../types/action.types';
+import PropTypes from 'prop-types';
 
 export interface Option {
   value: string;

--- a/src/components/forms/Select/useSelectProps.ts
+++ b/src/components/forms/Select/useSelectProps.ts
@@ -1,3 +1,5 @@
+import type { SelectProps } from './Select.types';
+
 import { useTheme } from 'styled-components';
 import { useDeepCompareMemo } from 'use-deep-compare';
 import { has, sortBy } from 'ramda';
@@ -15,7 +17,6 @@ import {
   reactSelectTheme,
   selectStyles,
 } from './Select.styles';
-import { SelectProps } from './Select.types';
 
 export const useSelectProps = <IsMulti extends boolean>({
   options = [],

--- a/src/components/forms/SelectableGroup/SelectableGroup.stories.tsx
+++ b/src/components/forms/SelectableGroup/SelectableGroup.stories.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SelectableGroupProps } from './SelectableGroup.types';
+
+import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
 import SelectableGroup from './SelectableGroup';
-import { SelectableGroupProps } from './SelectableGroup.types';
 import { Stack } from '../../layout';
 import { Button } from '../../Button';
 

--- a/src/components/forms/SelectableGroup/SelectableGroup.test.tsx
+++ b/src/components/forms/SelectableGroup/SelectableGroup.test.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import { renderWithProviders } from '../../../utils/tests/renderWithProviders';

--- a/src/components/forms/SelectableGroup/SelectableGroup.tsx
+++ b/src/components/forms/SelectableGroup/SelectableGroup.tsx
@@ -1,5 +1,8 @@
 /* eslint-disable react/destructuring-assignment */
-import React, { useState } from 'react';
+import type { ChangeEvent, FC } from 'react';
+import type { Option, SelectableGroupProps } from './SelectableGroup.types';
+
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { isNotUndefined, noop } from 'ramda-adjunct';
 import styled from 'styled-components';
@@ -9,7 +12,6 @@ import { pipe, sort } from 'ramda';
 import cls from 'classnames';
 
 import { Cluster, Padbox } from '../../layout';
-import { Option, SelectableGroupProps } from './SelectableGroup.types';
 import {
   getColor,
   getFontSize,
@@ -72,7 +74,7 @@ const getNextValue = (value: string, currentValues: string[]) => {
   return currentValues.filter((cv) => cv !== value);
 };
 
-const SelectableGroup: React.FC<SelectableGroupProps> = ({
+const SelectableGroup: FC<SelectableGroupProps> = ({
   isMulti = false,
   onChange = noop,
   value: valueFromProps,
@@ -91,7 +93,7 @@ const SelectableGroup: React.FC<SelectableGroupProps> = ({
   );
   const value = isControlled ? valueFromProps : internalValue;
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = isMulti
       ? getNextValue(e.target.value, value as string[])
       : e.target.value;

--- a/src/components/forms/Switch/Switch.stories.tsx
+++ b/src/components/forms/Switch/Switch.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, Story } from '@storybook/react/types-6-0';
-import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { SwitchProps } from './Switch.types';
 
 import { SpaceSizes } from '../../../theme/space.enums';
 import { generateControl } from '../../../utils/tests/storybook';
@@ -8,7 +8,6 @@ import { Stack } from '../../layout/Stack';
 import { Paragraph } from '../../typographyLegacy';
 import Switch from './Switch';
 import { SwitchSizes } from './Switch.enums';
-import { SwitchProps } from './Switch.types';
 
 export default {
   title: 'components/forms/Switch',

--- a/src/components/forms/Switch/Switch.tsx
+++ b/src/components/forms/Switch/Switch.tsx
@@ -1,4 +1,6 @@
-import React, { forwardRef } from 'react';
+import type { Sizes, SwitchLabelProps, SwitchProps } from './Switch.types';
+
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { __, pipe, subtract } from 'ramda';
@@ -14,7 +16,6 @@ import {
   getToken,
   pxToRem,
 } from '../../../utils';
-import { Sizes, SwitchLabelProps, SwitchProps } from './Switch.types';
 import { SwitchSizes } from './Switch.enums';
 import { CLX_COMPONENT } from '../../../theme/constants';
 

--- a/src/components/forms/Switch/Switch.types.ts
+++ b/src/components/forms/Switch/Switch.types.ts
@@ -1,6 +1,5 @@
-import React from 'react';
-
-import { SwitchSizes } from './Switch.enums';
+import type { ComponentPropsWithRef } from 'react';
+import type { SwitchSizes } from './Switch.enums';
 
 export type Sizes = typeof SwitchSizes[keyof typeof SwitchSizes];
 
@@ -11,7 +10,7 @@ export interface SwitchLabelProps {
 }
 
 export interface SwitchProps
-  extends Omit<React.ComponentPropsWithRef<'input'>, 'size'> {
+  extends Omit<ComponentPropsWithRef<'input'>, 'size'> {
   /**
    * ID to connect input and its label
    */

--- a/src/components/forms/TextArea/TextArea.stories.tsx
+++ b/src/components/forms/TextArea/TextArea.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { TextAreaProps } from './TextArea.types';
 
 import TextArea from './TextArea';
-import { TextAreaProps } from './TextArea.types';
 
 export default {
   title: 'components/forms/TextArea',

--- a/src/components/forms/TextArea/TextArea.test.tsx
+++ b/src/components/forms/TextArea/TextArea.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import TextArea from './TextArea';

--- a/src/components/forms/TextArea/TextArea.tsx
+++ b/src/components/forms/TextArea/TextArea.tsx
@@ -1,4 +1,7 @@
-import React, { useRef, useState } from 'react';
+import type { ChangeEventHandler, FC, PropsWithRef } from 'react';
+import type { TextAreaProps } from './TextArea.types';
+
+import { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { isNotUndefined, noop } from 'ramda-adjunct';
@@ -16,7 +19,6 @@ import {
   getSpace,
   pxToRem,
 } from '../../../utils';
-import { TextAreaProps } from './TextArea.types';
 import { useAutosize } from './hooks/useAutosize';
 import { useRunAfterUpdate } from './hooks/useRunAfterUpdate';
 import { SpaceSizes } from '../../../theme';
@@ -91,8 +93,8 @@ const Counter = styled.span<{ isInvalid: boolean }>`
     `}
 `;
 
-const TextArea: React.FC<
-  TextAreaProps & React.PropsWithRef<JSX.IntrinsicElements['textarea']>
+const TextArea: FC<
+  TextAreaProps & PropsWithRef<JSX.IntrinsicElements['textarea']>
 > = ({
   maxLength,
   isInvalid = false,
@@ -108,7 +110,7 @@ const TextArea: React.FC<
   } = props as {
     value: string;
     defaultValue: string;
-    onChange: React.ChangeEventHandler;
+    onChange: ChangeEventHandler;
   };
   const textAreaRef = useRef<HTMLTextAreaElement>();
   const { text, parentHeight, textAreaHeight, autosize } = useAutosize(

--- a/src/components/forms/TextArea/hooks/useAutosize.ts
+++ b/src/components/forms/TextArea/hooks/useAutosize.ts
@@ -1,4 +1,6 @@
-import React, { useLayoutEffect, useState } from 'react';
+import type { MutableRefObject } from 'react';
+
+import { useLayoutEffect, useState } from 'react';
 import { isNotUndefined } from 'ramda-adjunct';
 import { path } from 'ramda';
 
@@ -8,7 +10,7 @@ const getHeight = (ref) => {
 };
 
 export const useAutosize = (
-  ref: React.MutableRefObject<HTMLTextAreaElement>,
+  ref: MutableRefObject<HTMLTextAreaElement>,
   value: string,
 ): {
   text: string;

--- a/src/components/forms/types/forms.types.ts
+++ b/src/components/forms/types/forms.types.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
 
 export interface TogglingInputProps {
   isInvalid?: boolean;
@@ -7,8 +7,8 @@ export interface TogglingInputProps {
 
 export interface TogglingProps
   extends TogglingInputProps,
-    React.InputHTMLAttributes<HTMLInputElement> {
+    InputHTMLAttributes<HTMLInputElement> {
   name: string;
-  label?: React.ReactNode;
+  label?: ReactNode;
   isDisabled?: boolean;
 }

--- a/src/components/layout/Center/Center.stories.tsx
+++ b/src/components/layout/Center/Center.stories.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { CenterProps } from './Center';
 
 import { SpaceSizes } from '../../../theme/space.enums';
 import { theme } from '../../../theme';
 import { Button } from '../../Button';
 import { Box } from '../mocks/Box';
-import Center, { CenterProps } from './Center';
+import Center from './Center';
 
 export default {
   title: 'layout/primitives/Center',

--- a/src/components/layout/Center/Center.tsx
+++ b/src/components/layout/Center/Center.tsx
@@ -1,3 +1,5 @@
+import type { SpaceSize } from '../../../theme/space.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { includes } from 'ramda';
@@ -5,7 +7,6 @@ import { isNotUndefined } from 'ramda-adjunct';
 import cls from 'classnames';
 
 import { getSpace, pxToRem } from '../../../utils';
-import { SpaceSize } from '../../../theme/space.types';
 import { SpaceSizes } from '../../../theme/space.enums';
 import { CLX_LAYOUT } from '../../../theme/constants';
 

--- a/src/components/layout/Cluster/Cluster.stories.tsx
+++ b/src/components/layout/Cluster/Cluster.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ClusterProps } from './Cluster';
 
 import { SpaceSizes } from '../../../theme/space.enums';
 import { Box } from '../mocks/Box';
-import Cluster, { ClusterProps } from './Cluster';
+import Cluster from './Cluster';
 
 export default {
   title: 'layout/primitives/Cluster',

--- a/src/components/layout/Cluster/Cluster.tsx
+++ b/src/components/layout/Cluster/Cluster.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import type { ReactComponentLike } from 'prop-types';
+import type { Property } from 'csstype';
+import type { FC, HTMLAttributes } from 'react';
+import type { SpaceSize } from '../../../theme/space.types';
+
 import styled, { css } from 'styled-components';
-import PropTypes, { ReactComponentLike } from 'prop-types';
-import { Property } from 'csstype';
+import PropTypes from 'prop-types';
 import { prop } from 'ramda';
 import cls from 'classnames';
 
-import { SpaceSize } from '../../../theme/space.types';
 import { getSpace } from '../../../utils';
 import { SpaceSizes } from '../../../theme/space.enums';
 import {
@@ -24,7 +26,7 @@ interface ClusterParentProps {
   className?: string;
 }
 
-export interface ClusterProps extends React.HTMLAttributes<HTMLElement> {
+export interface ClusterProps extends HTMLAttributes<HTMLElement> {
   /**
    * Whitespace around each child of the Inline
    */
@@ -73,7 +75,7 @@ const ClusterParent = styled.div<ClusterParentProps>(
   },
 );
 
-const Cluster: React.FC<ClusterProps> = ({
+const Cluster: FC<ClusterProps> = ({
   children,
   gap,
   align,

--- a/src/components/layout/Col/Col.tsx
+++ b/src/components/layout/Col/Col.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { ColProps, Cols } from './Col.types';
+
 import { Box } from 'reflexbox';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { path, pipe } from 'ramda';
 
 import { pxToRem } from '../../../utils';
-import { ColProps, Cols } from './Col.types';
 import { CLX_LAYOUT } from '../../../theme/constants';
 
 const getColWidth = (cols: Cols): { flex: string } | { width: number } => {
@@ -25,7 +26,7 @@ const StyledCol = styled(Box)`
   padding-right: ${getColPadding};
 `;
 
-const Col: React.FC<ColProps> = ({ children, cols, offset }) => (
+const Col: FC<ColProps> = ({ children, cols, offset }) => (
   <StyledCol
     ml={`${(100 / 12) * offset}%`}
     {...getColWidth(cols)}

--- a/src/components/layout/Grid/Grid.stories.tsx
+++ b/src/components/layout/Grid/Grid.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { GridProps } from './Grid';
 
 import { SpaceSizes } from '../../../theme/space.enums';
 import { Box } from '../mocks/Box';
-import Grid, { GridProps } from './Grid';
+import Grid from './Grid';
 import { Card, CardContent, CardHeader } from '../../Card';
 import { Text } from '../../typographyLegacy';
 

--- a/src/components/layout/Grid/Grid.tsx
+++ b/src/components/layout/Grid/Grid.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import type { ReactComponentLike } from 'prop-types';
+import type { Property } from 'csstype';
+import type { FC, HTMLAttributes } from 'react';
+import type { SpaceSize } from '../../../theme/space.types';
+
 import styled, { css } from 'styled-components';
-import PropTypes, { ReactComponentLike } from 'prop-types';
-import { Property } from 'csstype';
+import PropTypes from 'prop-types';
 import { prop } from 'ramda';
 import cls from 'classnames';
 
 import { getSpace } from '../../../utils';
 import { SpaceSizes } from '../../../theme/space.enums';
-import { SpaceSize } from '../../../theme/space.types';
 import { AlignItemsPropType } from '../../../types/flex.types';
 import { CLX_LAYOUT } from '../../../theme/constants';
 import { useLogger } from '../../../hooks/useLogger';
@@ -21,7 +23,7 @@ interface GridParentProps {
   $cols?: number;
 }
 
-export interface GridProps extends React.HTMLAttributes<HTMLElement> {
+export interface GridProps extends HTMLAttributes<HTMLElement> {
   /**
    * Whitespace around each child of the Inline
    */
@@ -70,7 +72,7 @@ const GridParent = styled.div<GridParentProps>(
   },
 );
 
-const Grid: React.FC<GridProps> = ({
+const Grid: FC<GridProps> = ({
   children,
   gap,
   align,

--- a/src/components/layout/Inline/Inline.stories.tsx
+++ b/src/components/layout/Inline/Inline.stories.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { CSSProperties } from 'react';
+import type { InlineProps } from './Inline';
 
 import { SpaceSizes } from '../../../theme/space.enums';
 import { Box as MockBox } from '../mocks/Box';
-import Inline, { InlineProps } from './Inline';
+import Inline from './Inline';
 import { StretchEnum } from './Inline.enums';
 
 export default {
@@ -28,7 +29,7 @@ export default {
   },
 } as Meta;
 
-function Box({ style = {} }: { style?: React.CSSProperties }) {
+function Box({ style = {} }: { style?: CSSProperties }) {
   return <MockBox style={{ width: '150px', minHeight: '150px', ...style }} />;
 }
 

--- a/src/components/layout/Inline/Inline.tsx
+++ b/src/components/layout/Inline/Inline.tsx
@@ -1,15 +1,16 @@
+import type { Property } from 'csstype';
+import type { SpaceSize } from '../../../theme/space.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { prop } from 'ramda';
 import { isNotUndefined, isNumber } from 'ramda-adjunct';
-import { Property } from 'csstype';
 import cls from 'classnames';
 
 import {
   AlignItemsPropType,
   JustifyContentPropType,
 } from '../../../types/flex.types';
-import { SpaceSize } from '../../../theme/space.types';
 import { getSpace } from '../../../utils';
 import { SpaceSizes } from '../../../theme/space.enums';
 import { StretchEnum } from './Inline.enums';

--- a/src/components/layout/Padbox/Padbox.stories.tsx
+++ b/src/components/layout/Padbox/Padbox.stories.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { PadboxProps } from './Padbox';
+
 import styled from 'styled-components';
 
-import Padbox, { PadboxProps } from './Padbox';
+import Padbox from './Padbox';
 import { getColor } from '../../../utils';
 import { SpaceSizes } from '../../../theme/space.enums';
 import { generateControl } from '../../../utils/tests/storybook';

--- a/src/components/layout/Padbox/Padbox.tsx
+++ b/src/components/layout/Padbox/Padbox.tsx
@@ -1,12 +1,14 @@
-import styled, { DefaultTheme } from 'styled-components';
+import type { DefaultTheme } from 'styled-components';
+import type { SpaceSize } from '../../../theme/space.types';
+import type { PaddingType } from '../../../utils/space';
+
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import cls from 'classnames';
 
 import { SpaceSizes } from '../../../theme/space.enums';
-import { SpaceSize } from '../../../theme/space.types';
 import { createPadding } from '../../../utils';
 import { PaddingTypes } from './Padbox.enums';
-import { PaddingType } from '../../../utils/space';
 import { CLX_LAYOUT } from '../../../theme/constants';
 
 export interface PadboxProps {

--- a/src/components/layout/Row/Row.tsx
+++ b/src/components/layout/Row/Row.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { FC } from 'react';
+
 import { Flex } from 'reflexbox';
 import styled from 'styled-components';
 import { path, pipe } from 'ramda';
@@ -19,7 +20,7 @@ const StyledRow = styled(Flex).attrs((props) => ({
   ...props,
 }))``;
 
-const Row: React.FC = ({ children }) => (
+const Row: FC = ({ children }) => (
   <StyledRow flexWrap="wrap">{children}</StyledRow>
 );
 

--- a/src/components/layout/Stack/Stack.stories.tsx
+++ b/src/components/layout/Stack/Stack.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { StackProps } from './Stack';
 
 import { SpaceSizes } from '../../../theme/space.enums';
-import Stack, { StackProps } from './Stack';
+import Stack from './Stack';
 import { Button } from '../../Button';
 import { Box } from '../mocks/Box';
 

--- a/src/components/layout/Stack/Stack.tsx
+++ b/src/components/layout/Stack/Stack.tsx
@@ -1,12 +1,13 @@
+import type { Property } from 'csstype';
+import type { SpaceSize } from '../../../theme/space.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { prop } from 'ramda';
 import { isNotUndefined } from 'ramda-adjunct';
-import { Property } from 'csstype';
 import cls from 'classnames';
 
 import { SpaceSizes } from '../../../theme/space.enums';
-import { SpaceSize } from '../../../theme/space.types';
 import { getSpace } from '../../../utils';
 import { AlignItemsPropType } from '../../../types/flex.types';
 import { CLX_LAYOUT } from '../../../theme/constants';

--- a/src/components/layout/layout.stories.tsx
+++ b/src/components/layout/layout.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+
 import styled from 'styled-components';
 
 import { Col, Container, Row } from './index';

--- a/src/components/typographyLegacy/Heading/Heading.stories.tsx
+++ b/src/components/typographyLegacy/Heading/Heading.stories.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ReactChild } from 'react';
+import type { HeadingProps } from './Heading.types';
 
 import Heading, { H0, H1, H2, H3, H4, H5 } from './Heading';
-import { HeadingProps } from './Heading.types';
 import { HeadingSizes, HeadingVariants } from './Heading.enums';
 import { generateControl } from '../../../utils/tests/storybook';
 
@@ -27,9 +27,9 @@ export default {
   },
 } as Meta;
 
-export const Playground: Story<
-  HeadingProps & { children: React.ReactChild }
-> = (args) => <Heading {...args} />;
+export const Playground: Story<HeadingProps & { children: ReactChild }> = (
+  args,
+) => <Heading {...args} />;
 Playground.args = {
   children: 'Playground Heading',
 };

--- a/src/components/typographyLegacy/Heading/Heading.test.tsx
+++ b/src/components/typographyLegacy/Heading/Heading.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import Heading from './Heading';

--- a/src/components/typographyLegacy/Heading/Heading.tsx
+++ b/src/components/typographyLegacy/Heading/Heading.tsx
@@ -1,8 +1,15 @@
-import React from 'react';
+import type {
+  ComponentPropsWithRef,
+  ComponentPropsWithoutRef,
+  FC,
+} from 'react';
+import type { HeadingProps } from './Heading.types';
+
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { path } from 'ramda';
 import cls from 'classnames';
+import { createElement } from 'react';
 
 import {
   createSpacings,
@@ -13,7 +20,6 @@ import {
   getLineHeight,
 } from '../../../utils';
 import { HeadingSizes, HeadingVariants } from './Heading.enums';
-import { HeadingProps } from './Heading.types';
 import { CLX_TYPOGRAPHY } from '../../../theme/constants';
 
 const primaryVariant = css`
@@ -81,9 +87,7 @@ const headingSizes = {
   h5: HeadingH5,
 };
 
-const Heading: React.FC<
-  HeadingProps & React.ComponentProps<typeof HeadingH1>
-> = ({
+const Heading: FC<HeadingProps & ComponentPropsWithRef<typeof HeadingH1>> = ({
   children,
   size = HeadingSizes.h1,
   variant = HeadingVariants.primary,
@@ -97,7 +101,7 @@ const Heading: React.FC<
     ...props,
   };
 
-  return React.createElement(headingSizes[size], additionalProps, children);
+  return createElement(headingSizes[size], additionalProps, children);
 };
 
 Heading.propTypes = {
@@ -108,9 +112,10 @@ Heading.propTypes = {
 
 export default Heading;
 
-export const H0: React.FC<
-  Omit<React.ComponentProps<typeof Heading>, 'size'>
-> = ({ children, ...props }) => (
+export const H0: FC<Omit<ComponentPropsWithoutRef<typeof Heading>, 'size'>> = ({
+  children,
+  ...props
+}) => (
   <Heading size={HeadingSizes.h0} {...props}>
     {children}
   </Heading>
@@ -120,9 +125,10 @@ H0.propTypes = {
   variant: PropTypes.oneOf(Object.values(HeadingVariants)),
 };
 
-export const H1: React.FC<
-  Omit<React.ComponentProps<typeof Heading>, 'size'>
-> = ({ children, ...props }) => (
+export const H1: FC<Omit<ComponentPropsWithoutRef<typeof Heading>, 'size'>> = ({
+  children,
+  ...props
+}) => (
   <Heading size={HeadingSizes.h1} {...props}>
     {children}
   </Heading>
@@ -132,9 +138,10 @@ H1.propTypes = {
   variant: PropTypes.oneOf(Object.values(HeadingVariants)),
 };
 
-export const H2: React.FC<
-  Omit<React.ComponentProps<typeof Heading>, 'size'>
-> = ({ children, ...props }) => (
+export const H2: FC<Omit<ComponentPropsWithoutRef<typeof Heading>, 'size'>> = ({
+  children,
+  ...props
+}) => (
   <Heading size={HeadingSizes.h2} {...props}>
     {children}
   </Heading>
@@ -144,9 +151,10 @@ H2.propTypes = {
   variant: PropTypes.oneOf(Object.values(HeadingVariants)),
 };
 
-export const H3: React.FC<
-  Omit<React.ComponentProps<typeof Heading>, 'size'>
-> = ({ children, ...props }) => (
+export const H3: FC<Omit<ComponentPropsWithoutRef<typeof Heading>, 'size'>> = ({
+  children,
+  ...props
+}) => (
   <Heading size={HeadingSizes.h3} {...props}>
     {children}
   </Heading>
@@ -156,9 +164,10 @@ H3.propTypes = {
   variant: PropTypes.oneOf(Object.values(HeadingVariants)),
 };
 
-export const H4: React.FC<
-  Omit<React.ComponentProps<typeof Heading>, 'size'>
-> = ({ children, ...props }) => (
+export const H4: FC<Omit<ComponentPropsWithoutRef<typeof Heading>, 'size'>> = ({
+  children,
+  ...props
+}) => (
   <Heading size={HeadingSizes.h4} {...props}>
     {children}
   </Heading>
@@ -168,9 +177,10 @@ H4.propTypes = {
   variant: PropTypes.oneOf(Object.values(HeadingVariants)),
 };
 
-export const H5: React.FC<
-  Omit<React.ComponentProps<typeof Heading>, 'size'>
-> = ({ children, ...props }) => (
+export const H5: FC<Omit<ComponentPropsWithoutRef<typeof Heading>, 'size'>> = ({
+  children,
+  ...props
+}) => (
   <Heading size={HeadingSizes.h5} {...props}>
     {children}
   </Heading>

--- a/src/components/typographyLegacy/Heading/Heading.types.tsx
+++ b/src/components/typographyLegacy/Heading/Heading.types.tsx
@@ -1,5 +1,5 @@
-import { HeadingSizes, HeadingVariants } from './Heading.enums';
-import { SpacingProps } from '../../../types/spacing.types';
+import type { HeadingSizes, HeadingVariants } from './Heading.enums';
+import type { SpacingProps } from '../../../types/spacing.types';
 
 export type Sizes = typeof HeadingSizes[keyof typeof HeadingSizes];
 export type Variants = typeof HeadingVariants[keyof typeof HeadingVariants];

--- a/src/components/typographyLegacy/Link/Link.stories.tsx
+++ b/src/components/typographyLegacy/Link/Link.stories.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { LinkProps } from './Link.types';
+
 import { action } from '@storybook/addon-actions';
-import { Meta, Story } from '@storybook/react/types-6-0';
 
 import { TextSizes, TextVariants } from '../Text/Text.enums';
 import { Paragraph } from '../index';
 import { LinkColors } from '../../_internal/BaseLink/BaseLink.enums';
 import Link from './Link';
 import { generateControl } from '../../../utils/tests/storybook';
-import { LinkProps } from './Link.types';
 
 export default {
   title: 'components/typography/Link',

--- a/src/components/typographyLegacy/Link/Link.tsx
+++ b/src/components/typographyLegacy/Link/Link.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { ComponentPropsWithRef, FC } from 'react';
+import type { LinkProps } from './Link.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { isNotNull, isNull } from 'ramda-adjunct';
@@ -6,7 +8,6 @@ import cls from 'classnames';
 
 import { requireRouterLink } from '../../../utils/require-router-link';
 import { LinkColors } from '../../_internal/BaseLink/BaseLink.enums';
-import { LinkProps } from './Link.types';
 import {
   LinkActiveStyles,
   LinkBaseStyles,
@@ -31,7 +32,7 @@ const LinkRoot = styled.a`
   }
 `;
 
-const Link: React.FC<LinkProps & React.ComponentProps<typeof LinkRoot>> = ({
+const Link: FC<LinkProps & ComponentPropsWithRef<typeof LinkRoot>> = ({
   children,
   color = LinkColors.primary,
   as = null,

--- a/src/components/typographyLegacy/Link/Link.types.ts
+++ b/src/components/typographyLegacy/Link/Link.types.ts
@@ -1,10 +1,9 @@
-import React from 'react';
 import type { To } from 'history';
-
-import { Colors } from '../../_internal/BaseLink';
+import type { MouseEventHandler } from 'react';
+import type { Colors } from '../../_internal/BaseLink';
 
 export interface LinkProps {
-  onClick?: React.MouseEventHandler;
+  onClick?: MouseEventHandler;
   href?: string;
   to?: To;
   color?: Colors;

--- a/src/components/typographyLegacy/Paragraph/Paragraph.stories.tsx
+++ b/src/components/typographyLegacy/Paragraph/Paragraph.stories.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ParagraphProps } from './Paragraph.types';
 
 import { Text } from '../index';
 import { TextSizes, TextVariants } from '../Text/Text.enums';
-import { ParagraphProps } from './Paragraph.types';
 import Paragraph from './Paragraph';
 import { generateControl } from '../../../utils/tests/storybook';
 

--- a/src/components/typographyLegacy/Paragraph/Paragraph.tsx
+++ b/src/components/typographyLegacy/Paragraph/Paragraph.tsx
@@ -1,3 +1,5 @@
+import type { ParagraphProps } from './Paragraph.types';
+
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { path } from 'ramda';
@@ -6,7 +8,6 @@ import { SpacingSizeValuePropType } from '../../../types/spacing.types';
 import { createSpacings } from '../../../utils';
 import { Text } from '../Text';
 import { TextSizes, TextVariants } from '../Text/Text.enums';
-import { ParagraphProps } from './Paragraph.types';
 
 const Paragraph = styled(Text)<ParagraphProps>`
   margin-bottom: ${path([

--- a/src/components/typographyLegacy/Paragraph/Paragraph.types.ts
+++ b/src/components/typographyLegacy/Paragraph/Paragraph.types.ts
@@ -1,4 +1,6 @@
-import { SpacingProps } from '../../../types/spacing.types';
-import { Text } from '../Text';
+import type { ComponentPropsWithoutRef } from 'react';
+import type { SpacingProps } from '../../../types/spacing.types';
+import type { Text } from '../Text';
 
-export type ParagraphProps = SpacingProps & React.ComponentProps<typeof Text>;
+export type ParagraphProps = SpacingProps &
+  ComponentPropsWithoutRef<typeof Text>;

--- a/src/components/typographyLegacy/Text/Text.stories.tsx
+++ b/src/components/typographyLegacy/Text/Text.stories.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import type { Meta, Story } from '@storybook/react/types-6-0';
+import type { ReactChild } from 'react';
+import type { TextProps } from './Text.types';
 
 import { Stack } from '../../layout';
 import Text, { Code, Strong } from './Text';
-import { TextProps } from './Text.types';
 import { TextSizes, TextVariants } from './Text.enums';
 import { generateControl } from '../../../utils/tests/storybook';
 
@@ -28,7 +28,7 @@ export default {
 
 const lipsum = `Lorem ipsum dolor sit amet`;
 
-export const Playground: Story<TextProps & { children: React.ReactChild }> = (
+export const Playground: Story<TextProps & { children: ReactChild }> = (
   args,
 ) => <Text {...args} />;
 Playground.args = {

--- a/src/components/typographyLegacy/Text/Text.tsx
+++ b/src/components/typographyLegacy/Text/Text.tsx
@@ -1,3 +1,6 @@
+import type { HeadingProps } from '../Heading/Heading.types';
+import type { CodeProps, StrongProps, TextProps } from './Text.types';
+
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import cls from 'classnames';
@@ -9,9 +12,7 @@ import {
   getFontWeight,
   getLineHeight,
 } from '../../../utils';
-import { HeadingProps } from '../Heading/Heading.types';
 import { TextSizes, TextVariants } from './Text.enums';
-import { CodeProps, StrongProps, TextProps } from './Text.types';
 import { CLX_TYPOGRAPHY } from '../../../theme/constants';
 
 const HeadingBase = css<HeadingProps>`

--- a/src/components/typographyLegacy/Text/Text.types.ts
+++ b/src/components/typographyLegacy/Text/Text.types.ts
@@ -1,4 +1,4 @@
-import { TextSizes, TextVariants } from './Text.enums';
+import type { TextSizes, TextVariants } from './Text.enums';
 
 export type Sizes = typeof TextSizes[keyof typeof TextSizes];
 export type Variants = typeof TextVariants[keyof typeof TextVariants];

--- a/src/hooks/components/DropdownPane.tsx
+++ b/src/hooks/components/DropdownPane.tsx
@@ -1,4 +1,9 @@
-import React from 'react';
+import type { FC } from 'react';
+import type {
+  DropdownPaneProps,
+  DropdownPaneStyles,
+} from './DropdownPane.types';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { transparentize } from 'polished';
@@ -11,7 +16,6 @@ import {
   getRadii,
 } from '../../utils';
 import { useOuterClick } from '../useOuterCallback';
-import { DropdownPaneProps, DropdownPaneStyles } from './DropdownPane.types';
 
 export const StyledDropdownPane = styled.div<DropdownPaneStyles>`
   position: absolute;
@@ -27,7 +31,7 @@ export const StyledDropdownPane = styled.div<DropdownPaneStyles>`
     $isElevated && `box-shadow: 0 2px 6px 0 ${transparentize(0.85, '#000')}`};
 `;
 
-const DropdownPane: React.FC<DropdownPaneProps> = ({
+const DropdownPane: FC<DropdownPaneProps> = ({
   children,
   onClickOut,
   isElevated = false,

--- a/src/hooks/components/DropdownPane.types.ts
+++ b/src/hooks/components/DropdownPane.types.ts
@@ -1,8 +1,10 @@
+import type { CSSProperties } from 'react';
+
 export interface DropdownPaneStyles {
   $isElevated?: boolean;
 }
 export interface DropdownPaneProps extends DropdownPaneStyles {
   isElevated: DropdownPaneStyles['$isElevated'];
   onClickOut: () => void;
-  style: React.CSSProperties;
+  style: CSSProperties;
 }

--- a/src/hooks/useCalculatePortalPlacement.ts
+++ b/src/hooks/useCalculatePortalPlacement.ts
@@ -1,14 +1,15 @@
 // Inspired by David Gilbertson (https://codepen.io/davidgilbertson/pen/ooXVyw)
 
-import React, { useCallback } from 'react';
-
-import {
+import type { MutableRefObject } from 'react';
+import type {
   StyleProps,
   UseCalculatePortalPlacementOptions,
 } from './useCalculatePortalPlacement.types';
 
+import { useCallback } from 'react';
+
 export const useCalculatePortaPlacement = (
-  { current }: React.MutableRefObject<HTMLSpanElement>,
+  { current }: MutableRefObject<HTMLSpanElement>,
   { placement, width = 270, space = 5 }: UseCalculatePortalPlacementOptions,
 ): (() => StyleProps) => {
   return useCallback(() => {

--- a/src/hooks/useCalculatePortalPlacement.types.ts
+++ b/src/hooks/useCalculatePortalPlacement.types.ts
@@ -1,4 +1,4 @@
-import { PortalPlacements } from './useCalculatePortalPlacements.enums';
+import type { PortalPlacements } from './useCalculatePortalPlacements.enums';
 
 export type StyleProps = {
   space: number;

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
+import type { InteractiveElement } from '../components/Dropdown/Dropdown.types';
 
-import { InteractiveElement } from '../components/Dropdown/Dropdown.types';
+import { useEffect } from 'react';
 
 const interactiveElSelector = `
     a[href],

--- a/src/hooks/useLogger.test.tsx
+++ b/src/hooks/useLogger.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { noop } from 'ramda-adjunct';
 

--- a/src/hooks/useOuterCallback.ts
+++ b/src/hooks/useOuterCallback.ts
@@ -1,8 +1,11 @@
-import React, { useEffect, useRef } from 'react';
+import type { MutableRefObject } from 'react';
+import type { MouseEventHandler } from 'react-select';
+
+import { useEffect, useRef } from 'react';
 
 export const useOuterClick = <E extends HTMLElement>(
-  callback: (e: React.MouseEvent) => void,
-): React.MutableRefObject<E> => {
+  callback: MouseEventHandler,
+): MutableRefObject<E> => {
   const innerRef = useRef<E>(null);
   const callbackRef = useRef(null);
 

--- a/src/hooks/usePopup.ts
+++ b/src/hooks/usePopup.ts
@@ -1,7 +1,9 @@
+import type { PopperProps } from 'react-popper';
+import type { Placement } from '@popperjs/core';
+import type { Options as ArrowOptions } from '@popperjs/core/lib/modifiers/arrow';
+
+import { usePopper } from 'react-popper';
 import { isNotUndefined } from 'ramda-adjunct';
-import { PopperProps, usePopper } from 'react-popper';
-import { Placement } from '@popperjs/core';
-import { Options as ArrowOptions } from '@popperjs/core/lib/modifiers/arrow';
 import { useTheme } from 'styled-components';
 
 type UsePopup<

--- a/src/hooks/usePortal.ts
+++ b/src/hooks/usePortal.ts
@@ -1,6 +1,9 @@
-import React, { useContext } from 'react';
+import type { FC } from 'react';
+import type { OnHide, OnShow, RCPF } from 'react-cool-portal';
+
+import { useContext } from 'react';
 import { noop } from 'ramda-adjunct';
-import useCoolPortal, { OnHide, OnShow, RCPF } from 'react-cool-portal';
+import useCoolPortal from 'react-cool-portal';
 
 import { DSContext } from '../theme/DSProvider/DSProvider';
 
@@ -14,7 +17,7 @@ type UsePortal = (config?: {
   showPortal: RCPF;
   hidePortal: RCPF;
   isPortalVisible: boolean;
-  Portal: React.FC;
+  Portal: FC;
 };
 
 export const usePortal: UsePortal = ({

--- a/src/managers/BannersManager/BannersProvider.test.tsx
+++ b/src/managers/BannersManager/BannersProvider.test.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+
 import { renderHook } from '@testing-library/react-hooks';
 
 import { BannersProvider, useBanners } from './BannersProvider';
@@ -15,7 +16,7 @@ describe('BannersManager/useBanners', () => {
   });
 
   it('should return context value', () => {
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+    const wrapper = ({ children }: { children: ReactNode }) => (
       <BannersProvider>{children}</BannersProvider>
     );
     const { result } = renderHook(() => useBanners(), { wrapper });

--- a/src/managers/BannersManager/BannersProvider.tsx
+++ b/src/managers/BannersManager/BannersProvider.tsx
@@ -1,7 +1,9 @@
-import React, { useMemo } from 'react';
-
+import type { ReactNode } from 'react';
 import type { Banner, BannersContextProps } from './types';
 import type { InstanceId } from '../common/types';
+
+import { useMemo } from 'react';
+
 import { useBannersState } from './useBannersState';
 import { createCtx } from '../common/createCtx';
 import { ACTIONS } from './enums';
@@ -13,11 +15,7 @@ const BannersContext = createCtx<BannersContextProps>(
 );
 
 export const useBanners = BannersContext.useContext;
-export const BannersProvider = ({
-  children,
-}: {
-  children: React.ReactNode;
-}) => {
+export const BannersProvider = ({ children }: { children: ReactNode }) => {
   const { state, addBanner, removeBanner } = useBannersState();
 
   const context = useMemo(

--- a/src/managers/BannersManager/BannersStack.stories.tsx
+++ b/src/managers/BannersManager/BannersStack.stories.tsx
@@ -1,5 +1,8 @@
-import React, { useEffect, useState } from 'react';
 import type { Meta, Story } from '@storybook/react';
+import type { BannerProps } from '../../components/Banner/Banner.types';
+import type { BannersStackProps } from './types';
+
+import { useEffect, useState } from 'react';
 import { useDeepCompareEffect } from 'use-deep-compare';
 import { pluck } from 'ramda';
 
@@ -22,8 +25,6 @@ import {
   Strong,
   Text,
 } from '../../components';
-import type { BannerProps } from '../../components/Banner/Banner.types';
-import type { BannersStackProps } from './types';
 import { BannerVariants } from '../../components/Banner/Banner.enums';
 
 export default {

--- a/src/managers/BannersManager/BannersStack.test.tsx
+++ b/src/managers/BannersManager/BannersStack.test.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+import type { BannerProps } from '../../components/Banner/Banner.types';
+
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -7,9 +9,8 @@ import { addBanner, removeBanner } from './events';
 import { BannersProvider } from './BannersProvider';
 import { Banner } from '../../components';
 import { renderWithProviders } from '../../utils/tests/renderWithProviders';
-import { BannerProps } from '../../components/Banner/Banner.types';
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
+const wrapper = ({ children }: { children: ReactNode }) => (
   <BannersProvider>{children}</BannersProvider>
 );
 const getBanner = (id: string, variant: BannerProps['variant'] = 'info') => ({

--- a/src/managers/BannersManager/BannersStack.tsx
+++ b/src/managers/BannersManager/BannersStack.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import type { BannersStackProps } from './types';
+
+import { cloneElement, useState } from 'react';
 import { indexOf, sort } from 'ramda';
 import { useDeepCompareEffect } from 'use-deep-compare';
 
 import { useBanners } from './BannersProvider';
-import type { BannersStackProps } from './types';
 
 const SORT_ORDER = ['error', 'warn', 'success', 'info'];
 const cmp = (a, b) => {
@@ -54,7 +55,7 @@ const BannersStack = ({ initialState = [] }: BannersStackProps) => {
     sortedInstances[index]?.component ||
     sortedInstances[sortedInstances.length - 1]?.component;
 
-  return React.cloneElement(currentComponent, {
+  return cloneElement(currentComponent, {
     onClose: handleRemove(currentComponent.props.onClose),
     __hasPagination: true,
     __onNext: moveToNext,

--- a/src/managers/BannersManager/events.test.tsx
+++ b/src/managers/BannersManager/events.test.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import type { ReactNode } from 'react';
+
 import { act, renderHook } from '@testing-library/react-hooks';
 
 import { BannersProvider, useBanners } from './BannersProvider';
@@ -10,7 +11,7 @@ const testBanner = {
   component: <Banner>test</Banner>,
 };
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
+const wrapper = ({ children }: { children: ReactNode }) => (
   <BannersProvider>{children}</BannersProvider>
 );
 describe('BannersManager/events', () => {

--- a/src/managers/BannersManager/events.ts
+++ b/src/managers/BannersManager/events.ts
@@ -1,7 +1,8 @@
-import { ACTIONS } from './enums';
 import type { Banner } from './types';
+import type { InstanceId } from '../common/types';
+
+import { ACTIONS } from './enums';
 import { createCustomEvent } from '../common/events';
-import { InstanceId } from '../common/types';
 
 export const addBanner = (banner: Required<Banner>) => {
   window.dispatchEvent(

--- a/src/managers/BannersManager/types.ts
+++ b/src/managers/BannersManager/types.ts
@@ -1,5 +1,5 @@
 import type { Instance, InstanceId, ManagerContext } from '../common/types';
-import { ACTIONS } from './enums';
+import type { ACTIONS } from './enums';
 
 type BannerBody = {
   component: JSX.Element;

--- a/src/managers/BannersManager/useBannersState.test.tsx
+++ b/src/managers/BannersManager/useBannersState.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, renderHook } from '@testing-library/react-hooks';
 
 import { useBannersState } from './useBannersState';

--- a/src/managers/BannersManager/useBannersState.ts
+++ b/src/managers/BannersManager/useBannersState.ts
@@ -1,8 +1,9 @@
+import type { Action, Banner } from './types';
+import type { InstanceId } from '../common/types';
+
 import { useReducer } from 'react';
 
-import type { Action, Banner } from './types';
 import { ACTIONS } from './enums';
-import { InstanceId } from '../common/types';
 import { addInstance, randomId, removeInstance } from '../common/utils';
 
 const reducer = (state: Required<Banner>[], action: Action) => {

--- a/src/managers/NotificationsManager/NotificationsProvider.stories.tsx
+++ b/src/managers/NotificationsManager/NotificationsProvider.stories.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
 import type { Meta, Story } from '@storybook/react';
+
+import { useState } from 'react';
 
 import { addNotification, removeNotification } from './api';
 import {

--- a/src/managers/NotificationsManager/NotificationsProvider.tsx
+++ b/src/managers/NotificationsManager/NotificationsProvider.tsx
@@ -1,15 +1,18 @@
-import React, { useReducer } from 'react';
+import type { ReactNode } from 'react';
+import type { Notification } from './types';
+
+import { useReducer } from 'react';
 
 import { Stack, Toast } from '../../components';
 import { ToastArea } from '../../components/Toast/Toast';
 import { useManagerEvents } from '../common/useManagerEvents';
-import { ACTIONS, Notification } from './types';
+import { ACTIONS } from './types';
 import { NotificationsProviderReducer } from './reducer';
 
 export const NotificationsProvider = ({
   children,
 }: {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }) => {
   const [state, dispatch] = useReducer(NotificationsProviderReducer, []);
 

--- a/src/managers/NotificationsManager/api.ts
+++ b/src/managers/NotificationsManager/api.ts
@@ -1,5 +1,7 @@
+import type { Notification } from './types';
+
 import { createCustomEvent } from '../common/events';
-import { ACTIONS, Notification } from './types';
+import { ACTIONS } from './types';
 
 export const removeNotification = (id: string) => {
   window.dispatchEvent(

--- a/src/managers/NotificationsManager/reducer.ts
+++ b/src/managers/NotificationsManager/reducer.ts
@@ -1,4 +1,6 @@
-import { ACTIONS, Notification } from './types';
+import type { Notification } from './types';
+
+import { ACTIONS } from './types';
 
 type NotificationAction =
   | {

--- a/src/managers/NotificationsManager/types.ts
+++ b/src/managers/NotificationsManager/types.ts
@@ -1,6 +1,5 @@
-import React from 'react';
-
-import { Variants } from '../../components/_internal/BaseToastBanner/BaseToastBanner.types';
+import type { ReactNode } from 'react';
+import type { Variants } from '../../components/_internal/BaseToastBanner/BaseToastBanner.types';
 
 // eslint-disable-next-line
 export enum ACTIONS {
@@ -13,6 +12,6 @@ export type NotificationActions = typeof ACTIONS[keyof typeof ACTIONS];
 export interface Notification {
   id: string;
   variant?: Variants;
-  content: React.ReactNode;
+  content: ReactNode;
   autoDismiss?: boolean;
 }

--- a/src/managers/common/useManagerEvents.ts
+++ b/src/managers/common/useManagerEvents.ts
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
-
 import type { ValueOf } from './types';
+
+import { useEffect } from 'react';
 
 export const useManagerEvents = <A extends Record<string, string>>(listeners: {
   [key in ValueOf<A>]: (e: CustomEvent) => void;

--- a/src/managers/common/utils.ts
+++ b/src/managers/common/utils.ts
@@ -1,6 +1,6 @@
-import { find, findIndex, propEq, remove, update } from 'ramda';
-
 import type { InstanceId } from './types';
+
+import { find, findIndex, propEq, remove, update } from 'ramda';
 
 export const randomId = () =>
   Math.floor((1 + Math.random()) * 0x10000)

--- a/src/theme/DSProvider/DSProvider.test.tsx
+++ b/src/theme/DSProvider/DSProvider.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import styled from 'styled-components';
 

--- a/src/theme/DSProvider/DSProvider.tsx
+++ b/src/theme/DSProvider/DSProvider.tsx
@@ -1,20 +1,22 @@
-import React from 'react';
+import type { FC } from 'react';
+import type { DSContextValue, DSProviderProps } from './DSProvider.types';
+
 import PropTypes from 'prop-types';
 import { ThemeProvider } from 'styled-components';
 import { mergeDeepRight } from 'ramda';
+import { createContext } from 'react';
 
 import { createTheme } from '../theme';
 import { GlobalStyles } from '../GlobalStyles';
-import { DSContextValue, DSProviderProps } from './DSProvider.types';
 
 export const defaultDSContext = {
   portalsContainerId: 'portals',
   hasIncludedGlobalStyles: true,
   debugMode: false,
 };
-export const DSContext = React.createContext<DSContextValue>(defaultDSContext);
+export const DSContext = createContext<DSContextValue>(defaultDSContext);
 
-const DSProvider: React.FC<DSProviderProps> = ({
+const DSProvider: FC<DSProviderProps> = ({
   children,
   theme = {},
   config = {},

--- a/src/theme/DSProvider/DSProvider.types.ts
+++ b/src/theme/DSProvider/DSProvider.types.ts
@@ -1,4 +1,4 @@
-import { DefaultTheme } from 'styled-components';
+import type { DefaultTheme } from 'styled-components';
 
 export interface DSContextValue {
   portalsContainerId: string;

--- a/src/theme/buttons.ts
+++ b/src/theme/buttons.ts
@@ -1,5 +1,5 @@
-import { colors } from './colors';
-import { Buttons } from './buttons.types';
+import type { colors } from './colors';
+import type { Buttons } from './buttons.types';
 
 export const createButtons = (themeColors: typeof colors): Buttons => ({
   variants: {

--- a/src/theme/colors.types.ts
+++ b/src/theme/colors.types.ts
@@ -1,4 +1,4 @@
-import { ColorTypes } from './colors.enums';
+import type { ColorTypes } from './colors.enums';
 
 export type Color = typeof ColorTypes[keyof typeof ColorTypes];
 export type Colors = Record<Color, string>;

--- a/src/theme/createIconLibrary.stories.mdx
+++ b/src/theme/createIconLibrary.stories.mdx
@@ -1,11 +1,14 @@
-
 import { Meta, Props, IconGallery, IconItem } from '@storybook/addon-docs';
-import {flip, includes} from 'ramda';
+import { flip, includes } from 'ramda';
 
-import Icon from '../components/Icon/Icon'
-import { RegularIconNames, SolidIconNames, SSCIconNames, IconTypes } from './icons/icons.enums';
+import Icon from '../components/Icon/Icon';
+import {
+  RegularIconNames,
+  SolidIconNames,
+  SSCIconNames,
+  IconTypes,
+} from './icons/icons.enums';
 import createIconLibrary from './createIconLibrary';
-
 
 <Meta title="Theme/createIconLibrary()" />
 
@@ -17,7 +20,7 @@ System defined icons and you'll be able to use them later.
 
 ```jsx
 // main.js
-import React from 'react';
+
 import ReactDOM from 'react-dom';
 import App from './App';
 import { createIconLibrary } from '@securityscorecard/design-system';
@@ -28,12 +31,12 @@ ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById('root'),
 );
-
 ```
 
 ## Extending icons library
+
 By default we are including only minimal set of icon necessary for usage this library. However
 you can extend default set of icons in the library with icons provided by FontAwesome (either
 Free or Pro versions). All you have to do is provide array of icons as first argument of
@@ -48,7 +51,6 @@ import { createIconLibrary } from '@securityscorecard/design-system';
 
 createIconLibrary([fasBone, fab]);
 
-
 // Component.jsx
 export const Component = () => (
   <>
@@ -59,8 +61,9 @@ export const Component = () => (
 ```
 
 ## Default icon set
+
 <IconGallery>
-  {Object.values(SSCIconNames).map(iconName => (
+  {Object.values(SSCIconNames).map((iconName) => (
     <IconItem name={iconName} key={iconName}>
       <Icon name={iconName} type={IconTypes.ssc} />
     </IconItem>

--- a/src/theme/createIconLibrary.ts
+++ b/src/theme/createIconLibrary.ts
@@ -1,8 +1,9 @@
-import {
+import type {
   IconDefinition,
   IconPack,
-  library,
 } from '@fortawesome/fontawesome-svg-core';
+
+import { library } from '@fortawesome/fontawesome-svg-core';
 import { isNotUndefined } from 'ramda-adjunct';
 
 import * as SSCIcons from './icons';

--- a/src/theme/depths.ts
+++ b/src/theme/depths.ts
@@ -1,4 +1,4 @@
-import { Depths } from './depths.types';
+import type { Depths } from './depths.types';
 
 export const createDepths = (): Depths => ({
   dropdown: 1050,

--- a/src/theme/forms.ts
+++ b/src/theme/forms.ts
@@ -1,7 +1,8 @@
+import type { Forms } from './forms.types';
+import type { colors } from './colors';
+
 import { transparentize } from 'polished';
 
-import { Forms } from './forms.types';
-import { colors } from './colors';
 import { pxToRem } from '../utils';
 
 export const createForms = (themeColors: typeof colors): Forms => ({

--- a/src/theme/icons/_template.ts
+++ b/src/theme/icons/_template.ts
@@ -3,7 +3,7 @@
  * DO NOT FORGET to add license comment if you are adding icon from FontAwesome
  */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/angleDown.ts
+++ b/src/theme/icons/angleDown.ts
@@ -4,7 +4,7 @@
  * Copyright 2022 Fonticons, Inc.
  */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/angleLeft.ts
+++ b/src/theme/icons/angleLeft.ts
@@ -4,7 +4,7 @@
  * Copyright 2022 Fonticons, Inc.
  */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/angleRight.ts
+++ b/src/theme/icons/angleRight.ts
@@ -4,7 +4,7 @@
  * Copyright 2022 Fonticons, Inc.
  */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/angleUp.ts
+++ b/src/theme/icons/angleUp.ts
@@ -4,7 +4,7 @@
  * Copyright 2022 Fonticons, Inc.
  */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/arrowUp.ts
+++ b/src/theme/icons/arrowUp.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/ban.ts
+++ b/src/theme/icons/ban.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/banSolid.ts
+++ b/src/theme/icons/banSolid.ts
@@ -6,7 +6,7 @@
 
 /* solid - ban */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/caretDown.ts
+++ b/src/theme/icons/caretDown.ts
@@ -6,7 +6,7 @@
 
 /* solid - caret-down */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/check.ts
+++ b/src/theme/icons/check.ts
@@ -6,7 +6,7 @@
 
 /* solid - check */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/checkCircle.ts
+++ b/src/theme/icons/checkCircle.ts
@@ -6,7 +6,7 @@
 
 /* regular - circle-check */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/checkCircleSolid.ts
+++ b/src/theme/icons/checkCircleSolid.ts
@@ -6,7 +6,7 @@
 
 /* solid - circle-check */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/chevronDown.ts
+++ b/src/theme/icons/chevronDown.ts
@@ -6,7 +6,7 @@
 
 /* solid - chevron-down */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/chevronLeftRegular.ts
+++ b/src/theme/icons/chevronLeftRegular.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/chevronRight.ts
+++ b/src/theme/icons/chevronRight.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/chevronRightRegular.ts
+++ b/src/theme/icons/chevronRightRegular.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/cog.ts
+++ b/src/theme/icons/cog.ts
@@ -6,7 +6,7 @@
 
 /* solid - gear */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/ellipsisH.ts
+++ b/src/theme/icons/ellipsisH.ts
@@ -6,7 +6,7 @@
 
 /* solid - ellipsis */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/ellipsisV.ts
+++ b/src/theme/icons/ellipsisV.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/error.ts
+++ b/src/theme/icons/error.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/errorCircle.ts
+++ b/src/theme/icons/errorCircle.ts
@@ -4,7 +4,7 @@
  * Copyright 2022 Fonticons, Inc.
  */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/errorSolid.ts
+++ b/src/theme/icons/errorSolid.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/exclTriangle.ts
+++ b/src/theme/icons/exclTriangle.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/exclTriangleSolid.ts
+++ b/src/theme/icons/exclTriangleSolid.ts
@@ -6,7 +6,7 @@
 
 /* solid - triangle-exclamation */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/eye.ts
+++ b/src/theme/icons/eye.ts
@@ -6,7 +6,7 @@
 
 /* regular - eye */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/eyeSlash.ts
+++ b/src/theme/icons/eyeSlash.ts
@@ -6,7 +6,7 @@
 
 /* regular - eye-slash */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/filter.ts
+++ b/src/theme/icons/filter.ts
@@ -6,7 +6,7 @@
 
 /* solid - filter */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/gripDotsVertical.ts
+++ b/src/theme/icons/gripDotsVertical.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/infoCircle.ts
+++ b/src/theme/icons/infoCircle.ts
@@ -6,7 +6,7 @@
 
 /* solid - circle-info */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/lightbulb.ts
+++ b/src/theme/icons/lightbulb.ts
@@ -6,7 +6,7 @@
 
 /* regular - lightbulb */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/lock.ts
+++ b/src/theme/icons/lock.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/longArrowLeft.ts
+++ b/src/theme/icons/longArrowLeft.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/longArrowRight.ts
+++ b/src/theme/icons/longArrowRight.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/minus.ts
+++ b/src/theme/icons/minus.ts
@@ -6,7 +6,7 @@
 
 /* solid - minus */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/plus.ts
+++ b/src/theme/icons/plus.ts
@@ -6,7 +6,7 @@
 
 /* solid - plus */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/questionCircle.ts
+++ b/src/theme/icons/questionCircle.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/quoteSquare.ts
+++ b/src/theme/icons/quoteSquare.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/reorder.ts
+++ b/src/theme/icons/reorder.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/resize.ts
+++ b/src/theme/icons/resize.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/search.ts
+++ b/src/theme/icons/search.ts
@@ -6,7 +6,7 @@
 
 /* solid - magnifying-glass */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/sitemap.ts
+++ b/src/theme/icons/sitemap.ts
@@ -6,7 +6,7 @@
 
 /* solid - sitemap */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/sort.ts
+++ b/src/theme/icons/sort.ts
@@ -6,7 +6,7 @@
 
 /* solid - sort */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/sortDown.ts
+++ b/src/theme/icons/sortDown.ts
@@ -6,7 +6,7 @@
 
 /* solid - sort-down */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/sortUp.ts
+++ b/src/theme/icons/sortUp.ts
@@ -6,7 +6,7 @@
 
 /* solid - sort-up */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/table.ts
+++ b/src/theme/icons/table.ts
@@ -4,7 +4,7 @@
  * Copyright 2022 Fonticons, Inc.
  */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/times.ts
+++ b/src/theme/icons/times.ts
@@ -6,7 +6,7 @@
 
 /* solid - xmark */
 
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/upload.ts
+++ b/src/theme/icons/upload.ts
@@ -3,7 +3,7 @@
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)
  * Copyright 2022 Fonticons, Inc.
  */
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/icons/wrench.ts
+++ b/src/theme/icons/wrench.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IconDefinition,
   IconName,
   IconPrefix,

--- a/src/theme/layout.ts
+++ b/src/theme/layout.ts
@@ -1,4 +1,4 @@
-import { Layout } from './layout.types';
+import type { Layout } from './layout.types';
 
 export const createLayout = (): Layout => ({
   containerWidth: 1170,

--- a/src/theme/space.ts
+++ b/src/theme/space.ts
@@ -1,4 +1,4 @@
-import { Space } from './space.types';
+import type { Space } from './space.types';
 
 const spacingScale = [0, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128];
 

--- a/src/theme/space.types.ts
+++ b/src/theme/space.types.ts
@@ -1,4 +1,4 @@
-import { SpaceSizes } from './space.enums';
+import type { SpaceSizes } from './space.enums';
 
 export type SpaceSize = typeof SpaceSizes[keyof typeof SpaceSizes];
 export type Space = Record<SpaceSize, number>;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-console */
-import { DefaultTheme } from 'styled-components';
+import type { DefaultTheme } from 'styled-components';
+import type { RecursivePartial } from '../types/utils.types';
+
 import { mergeDeepRight } from 'ramda';
 
 import { colors as themeColors } from './colors';
@@ -10,7 +12,6 @@ import { createLayout } from './layout';
 import { createDepths } from './depths';
 import { createSpace } from './space';
 import { createRadii } from './radii';
-import { RecursivePartial } from '../types/utils.types';
 import { createTokens } from './tokens';
 
 export const createTheme = (

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -1,4 +1,4 @@
-import { colors as themeColors } from './colors';
+import type { colors as themeColors } from './colors';
 import type { Typography } from './typography.types';
 
 /**

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,6 +1,5 @@
-import { colors } from './colors';
-import { pxToRem } from '../utils';
-import {
+import type { colors } from './colors';
+import type {
   Family,
   LineHeight,
   Links,
@@ -9,6 +8,8 @@ import {
   Typography,
   Weight,
 } from './typography.types';
+
+import { pxToRem } from '../utils';
 import { BASE_FONT_SIZE, BASE_LINE_HEIGHT } from './constants';
 
 const family: Family = {

--- a/src/theme/typography.types.ts
+++ b/src/theme/typography.types.ts
@@ -1,4 +1,4 @@
-import { Sizes as HeadingSizes } from '../components/typographyLegacy/Heading/Heading.types';
+import type { Sizes as HeadingSizes } from '../components/typographyLegacy/Heading/Heading.types';
 
 export interface Family {
   base: string;

--- a/src/types/action.types.ts
+++ b/src/types/action.types.ts
@@ -1,6 +1,7 @@
 import type { To } from 'history';
+import type { ReactNode } from 'react';
+
 import PropTypes from 'prop-types';
-import React from 'react';
 
 import { ToPropType } from './to.types';
 
@@ -8,10 +9,10 @@ export type ActionBase<
   OnClickArgs extends Array<unknown>,
   OnClickReturnType = void,
 > = {
-  label: React.ReactNode;
+  label: ReactNode;
   name: string;
   onClick?: (...args: OnClickArgs) => OnClickReturnType;
-  tooltip?: React.ReactNode;
+  tooltip?: ReactNode;
 };
 
 export const ActionBasePropType = {

--- a/src/types/customPropTypes.ts
+++ b/src/types/customPropTypes.ts
@@ -1,7 +1,7 @@
+import type { TupleType, TypeChecker } from './customPropTypes.types';
+
 import { gt, length } from 'ramda';
 import { isEmptyArray, isNotArray, isUndefined } from 'ramda-adjunct';
-
-import { TupleType, TypeChecker } from './customPropTypes.types';
 
 // Taken from https://stackoverflow.com/a/51165301/2216488
 function CustomPropTypeError(message: string) {

--- a/src/types/definitions/react-table.d.ts
+++ b/src/types/definitions/react-table.d.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   UseColumnOrderInstanceProps,
   UseColumnOrderState,
   UseExpandedHooks,
@@ -47,8 +47,7 @@ import {
   UseSortByOptions,
   UseSortByState,
 } from 'react-table';
-
-import {
+import type {
   CustomColumnOptions,
   RowAction,
 } from '../../components/Datatable/Table/Table.types';

--- a/src/types/definitions/styled.d.ts
+++ b/src/types/definitions/styled.d.ts
@@ -1,14 +1,14 @@
 import 'styled-components';
 
-import { colors } from '../../theme/colors';
-import { createButtons } from '../../theme/buttons';
-import { createDepths } from '../../theme/depths';
-import { createForms } from '../../theme/forms';
-import { createLayout } from '../../theme/layout';
-import { createRadii } from '../../theme/radii';
-import { createSpace } from '../../theme/space';
-import { createTypography } from '../../theme/typography';
-import { tokens } from '../../theme/tokens';
+import type { colors } from '../../theme/colors';
+import type { createButtons } from '../../theme/buttons';
+import type { createDepths } from '../../theme/depths';
+import type { createForms } from '../../theme/forms';
+import type { createLayout } from '../../theme/layout';
+import type { createRadii } from '../../theme/radii';
+import type { createSpace } from '../../theme/space';
+import type { createTypography } from '../../theme/typography';
+import type { tokens } from '../../theme/tokens';
 
 declare module 'styled-components' {
   export interface DefaultTheme {

--- a/src/types/polymorphicComponent.types.ts
+++ b/src/types/polymorphicComponent.types.ts
@@ -1,18 +1,23 @@
-import React from 'react';
-
 /**
  * This code is taken from two articles written by Ben Ilegbodu (https://github.com/benmvp)
  * https://www.benmvp.com/blog/polymorphic-react-components-typescript/
  * https://www.benmvp.com/blog/forwarding-refs-polymorphic-react-component-typescript/
  */
 
-// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
-// A more precise version of just React.ComponentPropsWithoutRef on its own
-type PropsOf<
-  C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<unknown>,
-> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>;
+import type {
+  ComponentPropsWithRef,
+  ComponentPropsWithoutRef,
+  ElementType,
+  JSXElementConstructor,
+} from 'react';
 
-type AsProp<C extends React.ElementType> = {
+// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
+// A more precise version of just  ComponentPropsWithoutRef on its own
+type PropsOf<
+  C extends keyof JSX.IntrinsicElements | JSXElementConstructor<unknown>,
+> = JSX.LibraryManagedAttributes<C, ComponentPropsWithoutRef<C>>;
+
+type AsProp<C extends ElementType> = {
   /**
    * An override of the default HTML tag.
    * Can also be another React component.
@@ -36,7 +41,7 @@ type ExtendableProps<
  * attributes like aria roles. The component (`C`) must be passed in.
  */
 type InheritableElementProps<
-  C extends React.ElementType,
+  C extends ElementType,
   Props = Record<string, unknown>,
 > = ExtendableProps<PropsOf<C>, Props>;
 
@@ -45,20 +50,20 @@ type InheritableElementProps<
  * the passed in `as` prop will determine which props can be included
  */
 export type PolymorphicComponentProps<
-  C extends React.ElementType,
+  C extends ElementType,
   Props = Record<string, unknown>,
 > = InheritableElementProps<C, Props & AsProp<C>>;
 
 /**
  * Utility type to extract the `ref` prop from a polymorphic component
  */
-export type PolymorphicRef<C extends React.ElementType> =
-  React.ComponentPropsWithRef<C>['ref'];
+export type PolymorphicRef<C extends ElementType> =
+  ComponentPropsWithRef<C>['ref'];
 /**
  * A wrapper of `PolymorphicComponentProps` that also includes the `ref`
  * prop for the polymorphic component
  */
 export type PolymorphicComponentPropsWithRef<
-  C extends React.ElementType,
+  C extends ElementType,
   Props = Record<string, unknown>,
 > = PolymorphicComponentProps<C, Props> & { ref?: PolymorphicRef<C> };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,19 @@
-import { DefaultTheme } from 'styled-components';
+import type { DefaultTheme } from 'styled-components';
+import type {
+  Family as FontFamily,
+  Size as FontSize,
+  Weight as FontWeight,
+  LineHeight,
+} from '../theme/typography.types';
+import type { Color } from '../theme/colors.types';
+import type { Forms } from '../theme/forms.types';
+import type { SpacingSizeValue } from '../types/spacing.types';
+import type { Depths } from '../theme/depths.types';
+import type { SpaceSize } from '../theme/space.types';
+import type { createRadii } from '../theme/radii';
+
+import numeral from 'numeral';
+import { isString, list } from 'ramda-adjunct';
 import {
   curry,
   either,
@@ -13,23 +28,9 @@ import {
   unless,
   useWith,
 } from 'ramda';
-import { isString, list } from 'ramda-adjunct';
-import numeral from 'numeral';
 
 import { BASE_FONT_SIZE } from '../theme/constants';
-import {
-  Family as FontFamily,
-  Size as FontSize,
-  Weight as FontWeight,
-  LineHeight,
-} from '../theme/typography.types';
-import { Color } from '../theme/colors.types';
-import { Forms } from '../theme/forms.types';
-import { SpacingSizeValue } from '../types/spacing.types';
-import { Depths } from '../theme/depths.types';
-import { SpaceSize } from '../theme/space.types';
 import { ColorTypes } from '../theme/colors.enums';
-import { createRadii } from '../theme/radii';
 
 export type Theme = {
   theme?: DefaultTheme;

--- a/src/utils/mergeRefs.ts
+++ b/src/utils/mergeRefs.ts
@@ -1,4 +1,5 @@
-import { MutableRefObject, Ref } from 'react';
+import type { MutableRefObject, Ref } from 'react';
+
 import { forEach } from 'ramda';
 
 const isMutableRefObject = <T>(thing: unknown): thing is MutableRefObject<T> =>

--- a/src/utils/require-router-link.ts
+++ b/src/utils/require-router-link.ts
@@ -1,6 +1,8 @@
+import type { ReactNode } from 'react';
+
 import { logError } from '../hooks/useLogger';
 
-export const requireRouterLink = (): React.ReactNode | null => {
+export const requireRouterLink = (): ReactNode | null => {
   try {
     // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
     return require('react-router-dom').Link;

--- a/src/utils/space.ts
+++ b/src/utils/space.ts
@@ -1,17 +1,19 @@
-import {
+import type {
   DefaultTheme,
   FlattenSimpleInterpolation,
-  css,
 } from 'styled-components';
+import type { SpacingSizeValue } from '../types/spacing.types';
+import type { Theme } from './helpers';
+import type { SpaceSize } from '../theme/space.types';
+
+import { css } from 'styled-components';
 import { any, apply, concat, curry, isEmpty, path, pipe } from 'ramda';
 import { isNotUndefined, isNumber } from 'ramda-adjunct';
 
 import { BASE_LINE_HEIGHT } from '../theme/constants';
-import { SpacingSizeValue } from '../types/spacing.types';
 import { SpaceSizes } from '../theme/space.enums';
-import { Theme, pxToRem } from './helpers';
+import { pxToRem } from './helpers';
 import { PaddingTypes } from '../components/layout/Padbox/Padbox.enums';
-import { SpaceSize } from '../theme/space.types';
 
 export type PaddingType = typeof PaddingTypes[keyof typeof PaddingTypes];
 type PaddingSpaceProps = {

--- a/src/utils/tests/renderWithProviders.tsx
+++ b/src/utils/tests/renderWithProviders.tsx
@@ -1,5 +1,6 @@
-import { RenderOptions, RenderResult, render } from '@testing-library/react';
-import React from 'react';
+import type { RenderOptions, RenderResult } from '@testing-library/react';
+
+import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { DSProvider } from '../../theme/DSProvider';


### PR DESCRIPTION
This PR consists of two things:
1. adds explicit type imports and enforce it with a ESLint rule (here's why: https://levelup.gitconnected.com/improving-babel-support-for-typescript-with-type-only-imports-28cb209d9460)
2. remove React explicit imports (here's why: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)

Ref UXD-1109