### PR TITLE
fix(Radio): wrap component in relative container

### DIFF
--- a/src/components/forms/Radio/Radio.tsx
+++ b/src/components/forms/Radio/Radio.tsx
@@ -10,6 +10,10 @@ import { TogglingInputProps } from '../types/forms.types';
 import { RadioProps } from './Radio.types';
 import { CLX_COMPONENT } from '../../../theme/constants';
 
+const RadioContainer = styled.div`
+  position: relative;
+`;
+
 const RadioLabel = styled(Label)<
   React.HTMLProps<HTMLLabelElement> & { hasLabel: boolean }
 >`
@@ -102,7 +106,7 @@ const Radio: React.FC<RadioProps> = ({
   const hasLabel = isNotUndefined(label);
 
   return (
-    <div>
+    <RadioContainer>
       <RadioInput
         className={cls(CLX_COMPONENT, className)}
         disabled={isDisabled}
@@ -115,7 +119,7 @@ const Radio: React.FC<RadioProps> = ({
       <RadioLabel hasLabel={hasLabel} htmlFor={radioId}>
         {label}
       </RadioLabel>
-    </div>
+    </RadioContainer>
   );
 };
 


### PR DESCRIPTION
The position:fixed of the hidden input type=radio in the Radio component can cause height calculation issues in parent containers.

This fix ensures the input stays within the limits of its parent container, while avoiding any position bug.

![image](https://user-images.githubusercontent.com/1852256/230209412-b30aacf5-84aa-46b6-9207-0776bdfe5ffb.png)
