### PR TITLE
fix(types): fix types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "main": "build/index.js",
   "module": "build/index.es.js",
-  "types": "build/src/index.d.ts",
+  "types": "build/index.d.ts",
   "files": [
     "CHANGELOG.md",
     "LICENSE",

--- a/src/components/Datatable/index.ts
+++ b/src/components/Datatable/index.ts
@@ -1,2 +1,3 @@
 export { default as Datatable } from './Datatable';
 export * from './Datatable.types';
+export { CustomColumnOptions } from './Table/Table.types';


### PR DESCRIPTION
Back in v1.1.1 we removed unnecessary definition files. This change caused change of structure of the build folder.  We forgot to reflect this change in the types field in package.json. This caused that applications using DS weren't able to pick component types we are distributing with this package.