### PR TITLE
fix(ColumnsControl): fix incorrect syntax on PropTypes definition

### DIFF
--- a/src/components/Datatable/components/ColumnsControls/ColumnsControls.tsx
+++ b/src/components/Datatable/components/ColumnsControls/ColumnsControls.tsx
@@ -105,7 +105,7 @@ const ColumnsControls: React.FC<ColumnsControlsProps> = ({
 };
 
 ColumnsControls.propTypes = {
-  children: PropTypes.oneOf(PropTypes.func, PropTypes.node).isRequired,
+  children: PropTypes.oneOf([PropTypes.func, PropTypes.node]).isRequired,
   onClose: PropTypes.func.isRequired,
   onApply: PropTypes.func.isRequired,
   isOpen: PropTypes.bool,


### PR DESCRIPTION
Incorrect PropTypes syntax caused the following warning to show up in console

```
    Warning: Invalid arguments supplied to oneOf, expected an array, got 2 arguments. A common mistake is to write oneOf(x, y, z) instead of oneOf([x, y, z]).

      at printWarning (node_modules/prop-types/factoryWithTypeCheckers.js:23:15)
      at Object.onApply [as oneOf] (node_modules/prop-types/factoryWithTypeCheckers.js:314:11)
      at Object.<anonymous> (node_modules/@securityscorecard/design-system/src/components/Datatable/components/ColumnsControls/ColumnsControls.tsx:110:3)
```