### PR TITLE
fix(Tooltip): fix showing empty tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 
 import Tooltip from './Tooltip';
 import { renderWithProviders } from '../../utils/tests/renderWithProviders';
@@ -16,16 +16,28 @@ describe('Tooltip', () => {
       const tooltipParent = screen.getByText(childrenText);
       fireEvent.pointerMove(tooltipParent);
       expect(tooltipParent).toBeInTheDocument();
-      await waitFor(() => {
-        expect(screen.getByTestId('ssc-tooltip')).toBeInTheDocument();
-      });
+      expect(await screen.findByTestId('ssc-tooltip')).toBeInTheDocument();
     });
   });
   describe('when popup is not defined', () => {
-    it('should display children', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should display children', async () => {
       renderWithProviders(<Tooltip>{childrenText}</Tooltip>);
+      const tooltipParent = screen.getByText(childrenText);
+      fireEvent.pointerMove(tooltipParent);
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
 
       expect(screen.getByText(childrenText)).toBeInTheDocument();
+      expect(screen.queryByTestId('ssc-tooltip')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -3,6 +3,7 @@ import * as RadixTooltip from '@radix-ui/react-tooltip';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { pipe, prop } from 'ramda';
+import { isFalsy } from 'ramda-adjunct';
 
 import { Padbox } from '../layout';
 import { getColor, pxToRem } from '../../utils';
@@ -94,6 +95,9 @@ const Tooltip: React.FC<TooltipProps> = ({
     : placement.endsWith('-end')
     ? 'end'
     : 'center';
+
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  if (isFalsy(popup)) return <>{children}</>;
 
   return (
     <RadixTooltip.Provider>


### PR DESCRIPTION
If no `popup` was provided Tooltip component showed empty contatiner.