### PR TITLE
feat(Tabs): allow passing onClick to Tab component

### DIFF
--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { KeyboardEvent, MouseEvent } from 'react';
 import PropTypes from 'prop-types';
 
 import { TabProps } from './Tabs.types';
@@ -11,22 +11,31 @@ import BaseTabLabel from '../_internal/BaseTabs/BaseTabLabel';
 
 const Tab: React.FC<TabProps> = ({
   children,
-  isSelected,
-  isExpanded = false,
-  onClick,
   color,
-  variant = TabVariants.underline,
+  onClick,
   value,
+  __variant,
+  __isExpanded,
+  __isSelected,
+  __onSelectTab,
 }) => {
   const isLink = value?.toString()?.startsWith('/');
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLAnchorElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
-      onClick(value);
+      __onSelectTab(value);
     }
   };
   const handler = isLink
-    ? { to: value }
-    : { onClick: () => onClick(value), onKeyDown: (e) => handleKeyDown(e) };
+    ? { to: value, onClick }
+    : {
+        onClick: (e: MouseEvent<HTMLAnchorElement>) => {
+          __onSelectTab(value);
+          onClick?.(e);
+        },
+        onKeyDown: (e: KeyboardEvent<HTMLAnchorElement>) => {
+          handleKeyDown(e);
+        },
+      };
   let RouterLink = null;
 
   if (isLink) {
@@ -34,19 +43,19 @@ const Tab: React.FC<TabProps> = ({
   }
 
   const paddingSize =
-    variant === TabVariants.segmented
+    __variant === TabVariants.segmented
       ? SpaceSizes.sm
-      : variant === TabVariants.underline
+      : __variant === TabVariants.underline
       ? SpaceSizes.md
       : SpaceSizes.none;
 
   return (
     <BaseTabLabel
       $color={color}
-      $isExpanded={isExpanded}
-      $isSelected={isSelected}
-      $variant={variant}
-      aria-selected={isSelected}
+      $isExpanded={__isExpanded}
+      $isSelected={__isSelected}
+      $variant={__variant}
+      aria-selected={__isSelected}
       as={isLink ? RouterLink : 'a'}
       paddingSize={paddingSize}
       paddingType={PaddingTypes.squish}
@@ -62,10 +71,13 @@ const Tab: React.FC<TabProps> = ({
 Tab.propTypes = {
   children: PropTypes.node.isRequired,
   value: PropTypes.string.isRequired,
-  variant: PropTypes.oneOf(Object.values(TabVariants)),
-  isSelected: PropTypes.bool,
-  isExpanded: PropTypes.bool,
   color: PropTypes.oneOf([...Object.values(ColorTypes)]),
+  __variant: PropTypes.oneOf(Object.values(TabVariants)),
+  // eslint-disable-next-line
+  __isSelected: PropTypes.bool,
+  // eslint-disable-next-line
+  __isExpanded: PropTypes.bool,
+  __onSelectTab: PropTypes.func, // internal property
   onClick: PropTypes.func,
 };
 

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -37,15 +37,19 @@ const TabPanel = ({ title }) => (
 
 const TabsTemplate: Story<TabsProps> = (args) => (
   <Tabs {...args}>
-    <Tab value="overview">Overview</Tab>
-    <Tab value="inventory">
+    <Tab value="overview" onClick={action('tab-click')}>
+      Overview
+    </Tab>
+    <Tab value="inventory" onClick={action('tab-click')}>
       <Inline align="center" gap="sm">
         <Icon color="primary.500" name="reorder" style={{ fontSize: '1rem' }} />
         <span>Inventory</span>
         <Badge count={3} variant="neutral" />
       </Inline>
     </Tab>
-    <Tab value="profile">Profile</Tab>
+    <Tab value="profile" onClick={action('tab-click')}>
+      Profile
+    </Tab>
   </Tabs>
 );
 
@@ -116,8 +120,17 @@ export const RoutableTabs: Story<TabsProps> = (args) => {
         <Route
           component={({ match }) => (
             <Tabs {...args} selectedValue={match.url}>
-              <Tab value="/overview">Overview</Tab>
-              <Tab value="/inventory">Inventory</Tab>
+              <Tab
+                value="/overview"
+                onClick={(e) => {
+                  action('tab-click')(e);
+                }}
+              >
+                Overview
+              </Tab>
+              <Tab value="/inventory" onClick={action('tab-click')}>
+                Inventory
+              </Tab>
             </Tabs>
           )}
           path="*"

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -42,11 +42,11 @@ const Tabs: React.FC<TabsProps> = ({
         }
 
         return React.cloneElement(tab, {
-          variant,
-          isExpanded,
-          key: tab.props.value,
-          isSelected: selectedPatternMatcher(tab.props.value, selectedValue),
-          onClick: onSelectTab,
+          __key: tab.props.value,
+          __variant: variant,
+          __isExpanded: isExpanded,
+          __isSelected: selectedPatternMatcher(tab.props.value, selectedValue),
+          __onSelectTab: onSelectTab,
         });
       })}
     </Inline>

--- a/src/components/Tabs/Tabs.types.ts
+++ b/src/components/Tabs/Tabs.types.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 
 import { SpacingProps } from '../../types/spacing.types';
 import { BaseLabelProps } from '../_internal/BaseTabs/BaseTabLabel.types';
@@ -9,21 +9,23 @@ export interface LabelProps extends BaseLabelProps, PadboxProps {}
 export interface TabProps {
   children: React.ReactNode;
   color?: LabelProps['$color'];
-  isSelected?: LabelProps['$isSelected'];
-  isExpanded?: boolean;
-  onClick?: (selectedValue: React.ReactText) => void;
   value: React.ReactText;
-  variant?: LabelProps['$variant'];
+  onClick?: MouseEventHandler;
+  /** Internal properties */
+  __isSelected?: LabelProps['$isSelected'];
+  __isExpanded?: boolean;
+  __onSelectTab?: (selectedValue: React.ReactText) => void;
+  __variant?: LabelProps['$variant'];
 }
 
 export interface TabsProps extends SpacingProps {
-  variant?: LabelProps['$variant'];
+  variant?: TabProps['__variant'];
   selectedValue: React.ReactText;
   selectedPatternMatcher?: (
     value: React.ReactText,
     selectedValue: React.ReactText,
   ) => boolean;
-  onSelectTab?: (selectedValue: React.ReactText) => void;
+  onSelectTab?: TabProps['__onSelectTab'];
   children: React.ReactNode[];
-  isExpanded?: boolean;
+  isExpanded?: TabProps['__isExpanded'];
 }


### PR DESCRIPTION
This PR adds the ability to add the `onClick` handler to the `Tab` component. This property was previously hijacked by the `onSelectTab` passed from the parent component. I also clearly marked internal properties to prevent confusion.

Closes UXD-1384