### PR TITLE
fix(DatatableV2): fix minor issues

### DIFF
--- a/src/components/DatatableV2/Datatable.types.ts
+++ b/src/components/DatatableV2/Datatable.types.ts
@@ -19,7 +19,19 @@ import { Types as SSCIconTypes, SSCIcons } from '../Icon';
 
 export type DatatableColumnDef<D, V = unknown> = Omit<
   ColumnDef<D, V>,
-  'accessorFn' | 'accessorFn' | 'cell' | 'header'
+  | 'accessorFn'
+  | 'accessorFn'
+  | 'cell'
+  | 'header'
+  | 'aggregatedCell'
+  | 'aggregationFn'
+  | 'enableColumnFilter'
+  | 'enableGlobalFilter'
+  | 'enableGrouping'
+  | 'filterFn'
+  | 'footer'
+  | 'getGroupingValue'
+  | 'getUniqueValues'
 > & {
   /**
    * You can use this to compose cell value from multiple keys in data object.
@@ -37,8 +49,9 @@ export type DatatableColumnDef<D, V = unknown> = Omit<
    * You can extract full name with:
    * ```
    * {
-   *   header: 'fullname'
+   *   header: 'Full name'
    *   accessorFn: row => `${row.firstName} ${row.lastName}
+   *   id: 'fullname
    * }
    */
   accessorFn?: AccessorFn<D, V>;
@@ -54,7 +67,7 @@ export type DatatableColumnDef<D, V = unknown> = Omit<
    * }
    *
    * {
-   *   header: 'age'
+   *   header: 'Age'
    *   accessorKey: 'age
    * }
    */
@@ -185,8 +198,16 @@ interface CustomState {
   isLoading: boolean;
   showProgress: boolean;
 }
-export type DatatableInitialState = InitialTableState & CustomState;
-export type DatatableState = TableState & CustomState;
+export type DatatableInitialState = Omit<
+  InitialTableState,
+  'columnFilter' | 'globalFilter' | 'grouping' | 'rowPinning'
+> &
+  CustomState;
+export type DatatableState = Omit<
+  TableState,
+  'columnFilters' | 'globalFilter' | 'grouping' | 'rowPinning'
+> &
+  CustomState;
 
 export interface ParsedDatatableOptions<D>
   extends Omit<Partial<TableOptions<D>>, 'data' | 'columns'> {
@@ -324,7 +345,15 @@ export interface DatatableOptions<D>
    */
   enableColumnResizing?: boolean;
   /**
+   * Enables/disables expanding detail panel for all rows.
+   *
+   * @default false
+   */
+  enableExpanding?: boolean;
+  /**
    * Enables/disables button in the table header that expands all detail panels at once.
+   *
+   * @default false
    */
   enableExpandAll?: boolean;
   /**
@@ -345,6 +374,10 @@ export interface DatatableOptions<D>
    * @default false
    */
   enableMultiSort?: boolean;
+  /**
+   * @default false
+   */
+  enableMultiRemove?: boolean;
   /**
    * Enables/disables pagination for the table.
    *
@@ -410,9 +443,9 @@ export interface DatatableOptions<D>
    */
   onShowColumnSettings?: Dispatch<SetStateAction<boolean>>;
   /**
-   * Provide your own implementation of row details panel. This property accepts React component\
+   * Provide your own implementation of row details panel. This property accepts React component
    * with properties:
-   *  - `row`: current row, row data are accessible through `row.original`
+   *  - `row` - current row, row data are accessible through `row.original`
    *  - `table` - current instance of the table
    */
   renderDetailPanel?: (props: {

--- a/src/components/DatatableV2/columns.utils.ts
+++ b/src/components/DatatableV2/columns.utils.ts
@@ -38,7 +38,11 @@ export const prepareColumns = <D>({
   columnDefs.map((columnDef) => ({
     ...columnDef,
     id: columnDef.id ?? columnDef.accessorKey?.toString?.() ?? columnDef.header,
-    columnDefType: columnDef?.columnDefType ?? 'data',
+    columnDefType:
+      columnDef?.columnDefType ??
+      (!columnDef.accessorKey && !columnDef.accessorFn && columnDef.id)
+        ? 'display'
+        : 'data',
     enableSorting: columnDef?.enableSorting ?? true,
   }));
 

--- a/src/components/DatatableV2/header/HeaderCell.tsx
+++ b/src/components/DatatableV2/header/HeaderCell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { flexRender } from '@tanstack/react-table';
 import clx from 'classnames';
 
@@ -10,6 +10,15 @@ import HeaderCellResizeHandler from './HeaderCellResizeHandler';
 import { Inline } from '../../layout';
 import { Tooltip } from '../../Tooltip';
 import { useHasHorizontalScroll } from '../hooks/useHasHorizontalScroll';
+import { displayColumnIds } from '../hooks/useDisplayColumns';
+
+const getTextHeaderStyle = (
+  labelLength: number | undefined,
+): CSSProperties => ({
+  whiteSpace: (labelLength ?? 0) < 20 ? 'nowrap' : 'normal',
+  minWidth: `${Math.min(labelLength ?? 0, 4)}ch`,
+  overflow: 'hidden',
+});
 
 const HeaderCell = <D,>({
   header,
@@ -50,7 +59,7 @@ const HeaderCell = <D,>({
     table,
   });
   const headerElement = flexRender(headerComponent, getContext()) ?? cdHeader;
-
+  const headerStyle = getTextHeaderStyle(cdHeader?.length);
   return (
     <th
       key={id}
@@ -68,11 +77,7 @@ const HeaderCell = <D,>({
         }),
       }}
     >
-      {columnDefType === 'display' ? (
-        <Inline align="center" justify="center">
-          {headerElement}
-        </Inline>
-      ) : isPlaceholder ? null : (
+      {isPlaceholder ? null : columnDefType === 'data' ? (
         <Inline align="center" gap="xs" justify="space-between">
           <Inline align="center" style={{ overflow: 'hidden' }}>
             {/* I know what I'm doing here */}
@@ -80,12 +85,10 @@ const HeaderCell = <D,>({
             <div
               className="ds-table-header-cell-title"
               style={{
-                whiteSpace: (cdHeader?.length ?? 0) < 20 ? 'nowrap' : 'normal',
-                minWidth: `${Math.min(cdHeader?.length ?? 0, 4)}ch`,
-                overflow: columnDefType === 'data' ? 'hidden' : undefined,
+                ...headerStyle,
                 cursor: getCanSort() ? 'pointer' : undefined,
               }}
-              title={columnDefType === 'data' ? cdHeader : undefined}
+              title={cdHeader}
               onClick={getToggleSortingHandler()}
             >
               <Tooltip placement="top" popup={tooltipPopup}>
@@ -107,6 +110,22 @@ const HeaderCell = <D,>({
           {getCanResize() && (
             <HeaderCellResizeHandler header={header} table={table} />
           )}
+        </Inline>
+      ) : Object.values(displayColumnIds).indexOf(columnDef.id) > 0 ? (
+        <Inline align="center" justify="center">
+          {headerElement}
+        </Inline>
+      ) : (
+        <Inline align="center" justify="flex-start">
+          <div
+            className="ds-table-header-cell-title"
+            style={headerStyle}
+            title={cdHeader}
+          >
+            <Tooltip placement="top" popup={tooltipPopup}>
+              {headerElement}
+            </Tooltip>
+          </div>
         </Inline>
       )}
     </th>

--- a/src/components/DatatableV2/hooks/useDatatable.ts
+++ b/src/components/DatatableV2/hooks/useDatatable.ts
@@ -18,12 +18,18 @@ import {
   DatatableInitialState,
   DatatableInstance,
   DatatableOptions,
+  ParsedDatatableOptions,
 } from '../Datatable.types';
 import { displayColumnIds, useDisplayColumns } from './useDisplayColumns';
 import { useOptions } from './useOptions';
 import { useDebounce } from '../../../hooks/useDebounce';
 
-const getMaxRowsPerPageOption = (rowsPerPageOptions) => {
+const getMaxRowsPerPageOption = <D>(
+  tableOptions: ParsedDatatableOptions<D>,
+) => {
+  const { enableRowsPerPage, rowsPerPageOptions } = tableOptions;
+  if (!enableRowsPerPage) return null;
+
   if (Array.isArray(rowsPerPageOptions)) {
     return rowsPerPageOptions[rowsPerPageOptions.length - 1];
   }
@@ -69,7 +75,7 @@ export const useDatatable = <D>(
       pageIndex: initState?.pagination?.pageIndex ?? 0,
       pageSize:
         initState?.pagination?.pageSize ??
-        getMaxRowsPerPageOption(tableOptions.rowsPerPageOptions) ??
+        getMaxRowsPerPageOption(tableOptions) ??
         50,
     };
 

--- a/src/components/DatatableV2/hooks/useDisplayColumns.tsx
+++ b/src/components/DatatableV2/hooks/useDisplayColumns.tsx
@@ -37,7 +37,7 @@ export const useDisplayColumns = <D,>(
                 ? ({ table }) => <SelectButton table={table} isSelectAll />
                 : null,
             cell: SelectButton,
-            size: 37,
+            size: 40,
             ...tableOptions.defaultDisplayColumn,
           },
           tableOptions.enableRowActions && {

--- a/src/components/DatatableV2/panels/DetailPanel.tsx
+++ b/src/components/DatatableV2/panels/DetailPanel.tsx
@@ -14,7 +14,7 @@ const DetailPanel = <D,>({
   } = table;
   return (
     <tr className="ds-table-body-row ds-table-row ds-table-detail-panel">
-      <td colSpan={row.getVisibleCells().length}>
+      <td colSpan={row.getVisibleCells().length} style={{ flexGrow: 1 }}>
         {renderDetailPanel({ table, row })}
       </td>
     </tr>

--- a/src/components/DatatableV2/stories/DetailPanel.stories.tsx
+++ b/src/components/DatatableV2/stories/DetailPanel.stories.tsx
@@ -4,7 +4,7 @@ import { ExpandedState } from '@tanstack/react-table';
 
 import Datatable from '../Datatable';
 import Template, { Story } from './Template';
-import { Code } from '../../typographyLegacy';
+import Snippet from '../../Snippet/Snippet';
 import { Padbox } from '../../layout';
 
 export default {
@@ -17,9 +17,9 @@ export default {
 
 const Panel = ({ row }) => (
   <Padbox paddingSize="md">
-    <pre>
-      <Code size="sm">{JSON.stringify(row.original, null, 2)}</Code>
-    </pre>
+    <Snippet shouldDedent={false} isExpanded>
+      {JSON.stringify(row.original, null, 2)}
+    </Snippet>
   </Padbox>
 );
 

--- a/src/components/DatatableV2/stories/HeaderTooltip.stories.tsx
+++ b/src/components/DatatableV2/stories/HeaderTooltip.stories.tsx
@@ -3,6 +3,8 @@ import { ComponentMeta } from '@storybook/react';
 
 import Datatable from '../Datatable';
 import Template, { Story, columns } from './Template';
+import { DatatableColumn, DatatableHeader } from '../Datatable.types';
+import { DataSource } from '../mocks/data';
 
 export default {
   title: 'components/DatatableV2/HeaderTooltip',
@@ -12,7 +14,13 @@ export default {
   },
 } as ComponentMeta<typeof Datatable>;
 
-const TooltipComponent = ({ header, column }) => (
+const TooltipComponent = ({
+  header,
+  column,
+}: {
+  header: DatatableHeader<DataSource>;
+  column: DatatableColumn<DataSource>;
+}) => (
   <div>
     {column.columnDef.header} - {header.id}
   </div>


### PR DESCRIPTION
I noticed some minor issues during writing documentation. This PR fixes them.
- removed unnecessary props from TS definitions
- mark column without accessors as 'display' instead of 'data'
- make details panel grow to the full width
- make rows per page default value 50 if selector is not enabled
- fix display column text header styles