### PR TITLE
feat(Collapsible): add controlled mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@popperjs/core": "^2.11.4",
+    "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@react-aria/utils": "^3.12.0",

--- a/src/components/Collapsible/Collapsible.stories.tsx
+++ b/src/components/Collapsible/Collapsible.stories.tsx
@@ -1,46 +1,69 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { Meta, Story } from '@storybook/react/types-6-0';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import Collapsible from './Collapsible';
-import { CollapsibleProps } from './Collapsible.types';
+import { Button } from '../Button';
+import { Snippet } from '../Snippet';
+import { Stack } from '../layout';
 
 export default {
   component: Collapsible,
   title: 'components/Collapsible',
-} as Meta;
+} as ComponentMeta<typeof Collapsible>;
 
-export const Playground: Story<
-  CollapsibleProps & { children: React.ReactChild }
-> = (args) => <Collapsible {...args} />;
+type Story = ComponentStory<typeof Collapsible>;
+
+export const Playground: Story = (args) => <Collapsible {...args} />;
 Playground.args = {
   title: 'playground',
   subject: 'Collapsible',
   children:
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus pharetra magna lectus, a congue ex blandit vel. Donec id mi commodo eros porta tempus',
 };
-Playground.parameters = {
-  screenshot: { skip: true },
+Playground.parameters = { screenshot: { skip: true } };
+
+export const DefaultCollapsible: Story = (args) => <Collapsible {...args} />;
+DefaultCollapsible.args = {
+  subject: 'Website does not implement X-XSS-Protection Best Practices',
+  title: 'Resolve or Comment',
+  onOpen: action('onOpen'),
+  children:
+    'You have 256 findings related to Website does not implement X-XSS-Protection Best Practices',
 };
 
-export const DefaultCollapsible: Story = () => (
-  <Collapsible
-    subject="Website does not implement X-XSS-Protection Best Practices"
-    title="Resolve or Comment"
-    onOpen={action('onOpen')}
-  >
-    You have 256 findings related to Website does not implement X-XSS-Protection
-    Best Practices
-  </Collapsible>
-);
+export const OpenedCollapsible: Story = (args) => <Collapsible {...args} />;
+OpenedCollapsible.args = {
+  ...DefaultCollapsible.args,
+  defaultIsOpen: true,
+};
 
-export const OpenedCollapsible: Story = () => (
-  <Collapsible
-    subject="Website does not implement X-XSS-Protection Best Practices"
-    title="Resolve or Comment"
-    defaultIsOpened
-  >
-    You have 256 findings related to Website does not implement X-XSS-Protection
-    Best Practices
-  </Collapsible>
-);
+export const ControlledCollapsible: Story = (args) => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <Stack gap="md">
+      <Collapsible
+        isOpen={isOpen}
+        onOpenChange={(open) => setIsOpen(open)}
+        {...args}
+      />
+
+      <Button
+        variant="outline"
+        onClick={() => {
+          setIsOpen((prev) => !prev);
+        }}
+      >
+        Toggle
+      </Button>
+      <Snippet>
+        {`{
+          isOpen: ${isOpen},
+        }`}
+      </Snippet>
+    </Stack>
+  );
+};
+ControlledCollapsible.args = DefaultCollapsible.args;
+ControlledCollapsible.parameters = { screenshot: { skip: true } };

--- a/src/components/Collapsible/Collapsible.test.tsx
+++ b/src/components/Collapsible/Collapsible.test.tsx
@@ -1,0 +1,141 @@
+import React, { ReactNode, useState } from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { renderWithProviders } from '../../utils/tests/renderWithProviders';
+import { Collapsible } from './index';
+
+const ControllingComponent = ({
+  isOpen,
+  onOpenChange,
+  onOpen,
+  children,
+}: {
+  isOpen?: boolean;
+  onOpenChange: jest.Mock;
+  onOpen?: jest.Mock;
+  children: ReactNode;
+}) => {
+  const [controlledIsOpen, setControlledIsOpen] = useState(isOpen ?? false);
+  onOpenChange.mockImplementation((v) => setControlledIsOpen(v));
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setControlledIsOpen((prev) => !prev)}
+      >
+        toggle
+      </button>
+      <Collapsible
+        title="test"
+        isOpen={controlledIsOpen}
+        onOpenChange={onOpenChange}
+        onOpen={onOpen}
+      >
+        {children}
+      </Collapsible>
+    </>
+  );
+};
+
+describe('Collapsible', () => {
+  describe('uncontrolled mode', () => {
+    it('should be closed by default', () => {
+      renderWithProviders(
+        <Collapsible title="test">Collapsible content</Collapsible>,
+      );
+      expect(screen.queryByText('Collapsible content')).not.toBeInTheDocument();
+    });
+    it('should be opened when "defaultIsOpen" is true', () => {
+      renderWithProviders(
+        <Collapsible title="test" defaultIsOpen>
+          Collapsible content
+        </Collapsible>,
+      );
+      expect(screen.getByText('Collapsible content')).toBeInTheDocument();
+    });
+
+    it('should toggle open state on trigger click', async () => {
+      renderWithProviders(
+        <Collapsible title="test">Collapsible content</Collapsible>,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /test/i }));
+      expect(screen.getByText('Collapsible content')).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: /test/i }));
+      expect(screen.queryByText('Collapsible content')).not.toBeInTheDocument();
+    });
+    it('should close on trigger click if opened by default', async () => {
+      renderWithProviders(
+        <Collapsible title="test" defaultIsOpen>
+          Collapsible content
+        </Collapsible>,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /test/i }));
+      expect(screen.queryByText('Collapsible content')).not.toBeInTheDocument();
+    });
+    it('should call "onOpen" on trigger click', async () => {
+      const onOpenMock = jest.fn();
+      renderWithProviders(
+        <Collapsible title="test" onOpen={onOpenMock}>
+          Collapsible content
+        </Collapsible>,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /test/i }));
+      expect(onOpenMock).toBeCalledTimes(1);
+    });
+    it('should call "onOpen" only when is open', async () => {
+      const onOpenMock = jest.fn();
+      renderWithProviders(
+        <Collapsible title="test" onOpen={onOpenMock} defaultIsOpen>
+          Collapsible content
+        </Collapsible>,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /test/i }));
+      expect(onOpenMock).not.toBeCalled();
+    });
+  });
+
+  describe('controlled mode', () => {
+    it('should toggle open state on trigger click', async () => {
+      const onOpenChangeMock = jest.fn();
+      renderWithProviders(
+        <ControllingComponent onOpenChange={onOpenChangeMock}>
+          Collapsible content
+        </ControllingComponent>,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /test/i }));
+      expect(screen.getByText('Collapsible content')).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: /test/i }));
+      expect(screen.queryByText('Collapsible content')).not.toBeInTheDocument();
+    });
+
+    it('should toggle open state on external state change', async () => {
+      const onOpenChangeMock = jest.fn();
+      renderWithProviders(
+        <ControllingComponent onOpenChange={onOpenChangeMock}>
+          Collapsible content
+        </ControllingComponent>,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /toggle/i }));
+      expect(screen.getByText('Collapsible content')).toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: /toggle/i }));
+      expect(screen.queryByText('Collapsible content')).not.toBeInTheDocument();
+    });
+
+    it('should be opened when "isOpen" is true', () => {
+      const onOpenChangeMock = jest.fn();
+      renderWithProviders(
+        <ControllingComponent isOpen onOpenChange={onOpenChangeMock}>
+          Collapsible content
+        </ControllingComponent>,
+      );
+      expect(screen.getByText('Collapsible content')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Collapsible/Collapsible.types.ts
+++ b/src/components/Collapsible/Collapsible.types.ts
@@ -1,8 +1,19 @@
+import { ReactNode } from 'react';
+
 export interface CollapsibleProps {
-  className?: string;
-  defaultIsOpened?: boolean;
+  /** Main title, accepts custom react node */
+  title: ReactNode;
+  /** Content of collapsible panel */
+  children: ReactNode;
+  /** Second header line */
   subject?: string;
-  title: React.ReactNode;
+  /** (UNCONTROLLED) Default state of collapsible panel */
+  defaultIsOpen?: boolean;
+  /** (UNCONTROLLED) Callback fired when collapsible panel is opened */
   onOpen?: () => void;
-  children: React.ReactNode;
+  /** (CONTROLLED) Collapsible panel external state */
+  isOpen?: boolean;
+  /** (CONTROLLED) Callback fired on collapsible panel state change */
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,6 +3514,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-collapsible@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@radix-ui/react-collapsible@npm:1.0.3"
+  dependencies:
+    "@babel/runtime": ^7.13.10
+    "@radix-ui/primitive": 1.0.1
+    "@radix-ui/react-compose-refs": 1.0.1
+    "@radix-ui/react-context": 1.0.1
+    "@radix-ui/react-id": 1.0.1
+    "@radix-ui/react-presence": 1.0.1
+    "@radix-ui/react-primitive": 1.0.3
+    "@radix-ui/react-use-controllable-state": 1.0.1
+    "@radix-ui/react-use-layout-effect": 1.0.1
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0
+    react-dom: ^16.8 || ^17.0 || ^18.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 26976e4a72a3e0f4b2c62af2898b3e205c3652af46a3b41cda9a43567fe8381d9ef6afb0b29e3214c450b847f4f2099a533cffc5045844ecab290e9fa6114ca9
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-collection@npm:1.0.3":
   version: 1.0.3
   resolution: "@radix-ui/react-collection@npm:1.0.3"
@@ -4162,6 +4189,7 @@ __metadata:
     "@geometricpanda/storybook-addon-badges": ^0.2.1
     "@mdx-js/react": ^1.6.22
     "@popperjs/core": ^2.11.4
+    "@radix-ui/react-collapsible": ^1.0.3
     "@radix-ui/react-dropdown-menu": ^2.0.6
     "@radix-ui/react-tooltip": ^1.0.7
     "@react-aria/utils": ^3.12.0


### PR DESCRIPTION
This PR adds support for controlled (external) state management. The component was also internally rewritten to use RadixUI. The `defaultIsOpened` was renamed to `defaultIsOpen` to increase consistency with rest of the API.

Closes UXD-1437