### PR TITLE
fix(DatatableV2): show header when selection is disabled

### DIFF
--- a/src/components/DatatableV2/header/Header.tsx
+++ b/src/components/DatatableV2/header/Header.tsx
@@ -5,12 +5,17 @@ import HeaderRow from './HeaderRow';
 import { getSelectedRowsCount } from '../toolbar/Selection';
 
 const Header = <D,>({ table }: { table: DatatableInstance<D> }) => {
+  const {
+    options: { enableRowSelection },
+  } = table;
   const selectedRowsCount = getSelectedRowsCount<D>(table);
 
   return (
     <thead
       className="ds-table-header"
-      style={selectedRowsCount > 0 ? { display: 'none' } : null}
+      style={
+        enableRowSelection && selectedRowsCount > 0 ? { display: 'none' } : null
+      }
     >
       {table.getHeaderGroups().map((headerGroup) => (
         <HeaderRow


### PR DESCRIPTION
If `enableRowSelection` is set to `false` the selection state can still be used. In this case if selection is triggered from outside the table header will dissapear but the batch row will not be showed. This PR will prevent hiding the table header in this case.