### PR TITLE
toggling issues on select with controlled values

### DIFF
--- a/src/components/forms/Checkbox/Checkbox.tsx
+++ b/src/components/forms/Checkbox/Checkbox.tsx
@@ -45,6 +45,8 @@ const Mark = styled.svg`
 `;
 
 const CheckboxInput = styled.input<TogglingInputProps>`
+  height: ${getRemToggleSize};
+  width: ${getRemToggleSize};
   opacity: 0;
   position: absolute;
 

--- a/src/components/forms/Select/Select.stories.tsx
+++ b/src/components/forms/Select/Select.stories.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Meta, Story } from '@storybook/react/types-6-0';
 import { action } from '@storybook/addon-actions';
 
 import Select from './Select';
 import { Option, SelectProps } from './Select.types';
-import { Inline, Stack } from '../../layout';
+import { Inline, Padbox, Stack } from '../../layout';
 import { Pill } from '../../Pill';
 import { PillColors } from '../../Pill/Pill.enums';
 import { Heading } from '../../Heading';
 import { Text } from '../../Text';
+import { Label } from '../Label';
+import { Button } from '../../Button';
 
 const options = [
   { value: 'HR', label: 'Croatia', isDisabled: true },
@@ -420,5 +422,57 @@ export const AsyncSelect: Story<SelectProps<false>> = () => {
 };
 
 AsyncSelect.parameters = {
+  screenshot: { skip: true },
+};
+
+export const MultiSelectWithControlledValue: Story<SelectProps<true>> = (
+  args,
+) => {
+  const [selectedOptions, setSelectedOptions] = useState([
+    options[1],
+    options[2],
+  ]);
+
+  return (
+    <Stack gap="md">
+      <Select
+        {...args}
+        closeMenuOnSelect={false}
+        value={selectedOptions}
+        menuIsOpen
+        onChange={(values) => {
+          setSelectedOptions(values);
+        }}
+      />
+
+      <Padbox>
+        <Label isBold>Selected Values</Label>
+        <Stack gap="md">
+          {selectedOptions.map((option) => (
+            <Inline key={option.value} gap="sm">
+              <Label style={{ width: '100px' }}>{option.label}</Label>
+              <Button
+                variant="text"
+                onClick={() =>
+                  setSelectedOptions((prev) =>
+                    prev.filter((o) => o.value !== option.value),
+                  )
+                }
+              >
+                Remove
+              </Button>
+            </Inline>
+          ))}
+        </Stack>
+      </Padbox>
+    </Stack>
+  );
+};
+MultiSelectWithControlledValue.args = {
+  ...OptionsGroup.args,
+  isMenuPositionRelative: true,
+  isMulti: true,
+};
+MultiSelectWithControlledValue.parameters = {
   screenshot: { skip: true },
 };

--- a/src/components/forms/Select/Select.styles.tsx
+++ b/src/components/forms/Select/Select.styles.tsx
@@ -451,6 +451,13 @@ const CreateNewOption = styled.div.attrs<{ variant: 'text'; color: 'primary' }>(
   }
 `;
 
+const StyledCheckbox = styled(Checkbox)`
+  & label {
+    /* the htmlFor attributes makes the label clickable which disrupts the row selection */
+    pointer-events: none;
+  }
+`;
+
 export const Option: ComponentType<OptionProps<OptionType, boolean>> = (
   props,
 ) => {
@@ -482,7 +489,7 @@ export const Option: ComponentType<OptionProps<OptionType, boolean>> = (
     <div>
       <components.Option {...props}>
         <Inline gap={SpaceSizes.sm}>
-          <Checkbox
+          <StyledCheckbox
             checkboxId={`select-${label}`}
             checked={isSelected}
             isDisabled={isDisabled}


### PR DESCRIPTION
This draft PR fixes the issues we've been having with the Multi Select in Risk Control.

Here is the original ticket:
https://zitenote.atlassian.net/browse/MS-287

This draft PR is split separated in 3 commits, so you can checkout each step of the "fix" (which we may want to split across multiple PRs)

1 (`7ac6f4d0`): I created an interactive storybook test with a controlled value where we can remove items from external widgets. This reflects the scenario and issue we face in Risk Control,

![image](https://github.com/securityscorecard/design-system/assets/1852256/2dd6cbea-abdf-4fe0-b684-ce53c2361516)


2 (`bd7e1c6c`): This simple CSS fix makes the clickable area of the hidden checkbox input the same size as the displayed icon. I hardcoded `pxToRem(20)` (default was 13), but maybe there's a constant for this that we should use. @ajkl2533  ?

before:  

![Screenshot 2024-06-18 at 5 20 13 PM](https://github.com/securityscorecard/design-system/assets/1852256/1f566fb7-0903-4f6e-ae80-db30a594f242)
    
after:

![image](https://github.com/securityscorecard/design-system/assets/1852256/97897bdb-1030-4bbc-bf08-085b1b51bb59)

3 (`979917e0`): the presence of the `htmlFor` attribute on the `Checkbox`'s internal Label instance makes it trap mouse events, even if the label is readonly. This causes interference with the row selection in the Multi `React-Select`. This commit adds a `pointer-events: none` to the `Checkbox` style used in Option rendering.

See the below videos, which show the main issue we face in Risk Control

BEFORE

https://github.com/securityscorecard/design-system/assets/1852256/b83672bb-1f4e-45e7-8ead-e4e16c81349f


AFTER

https://github.com/securityscorecard/design-system/assets/1852256/2a7a6951-d47b-4dae-821b-d54a8c7f11b7
