### PR TITLE
fix(dialogs): render dropdowns in dialog context

### DIFF
--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { renderWithProviders } from '../../utils/tests/renderWithProviders';
@@ -6,6 +7,7 @@ import Drawer from './Drawer';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { Paragraph } from '../Paragraph';
+import { DropdownMenu } from '../DropdownMenu';
 import { Inline, Stack } from '../layout';
 import { pxToRem } from '../../utils/helpers';
 
@@ -103,5 +105,37 @@ describe('Drawer', () => {
 
     const content = screen.getByText('Whatever happens, happens here');
     expect(content).toBeInTheDocument();
+  });
+
+  it('should allow clicking on interactive elements in dropdown', () => {
+    const dropdownClickMock = jest.fn();
+    renderWithProviders(
+      <Drawer
+        size="md"
+        onClose={() => null}
+        title="Test drawer"
+        data-testid="drawer"
+      >
+        <DropdownMenu
+          actions={[
+            {
+              label: 'OnClick',
+              name: 'onClick',
+              onClick: dropdownClickMock,
+            },
+          ]}
+        >
+          <button type="button">Trigger</button>
+        </DropdownMenu>
+      </Drawer>,
+    );
+    userEvent.click(screen.getByRole('button', { name: /Trigger/i }));
+
+    const dropdownItem = screen.getByRole('button', { name: /OnClick/i });
+    expect(dropdownItem).toBeInTheDocument();
+
+    userEvent.click(dropdownItem);
+
+    expect(dropdownClickMock).toBeCalled();
   });
 });

--- a/src/components/Dropdown/ControlledDropdown.tsx
+++ b/src/components/Dropdown/ControlledDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from 'react';
+import React, { Fragment, forwardRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { SpaceSizes } from '../../theme';
@@ -10,6 +10,7 @@ import DropdownPane from './DropdownPane';
 import { DropdownPlacements } from './Dropdown.enums';
 import { mergeRefs } from '../../utils/mergeRefs';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { useFloatingContext } from '../../contexts/FloatingContext';
 
 const ControlledDropdown = forwardRef<
   HTMLDivElement,
@@ -44,9 +45,12 @@ const ControlledDropdown = forwardRef<
 
     useFocusTrap({ el: paneEl, enabled: isOpen && focusTrap });
     const { Portal } = usePortal();
+    const isInFloatingElement = useFloatingContext() ?? false;
+
+    const MaybePortal = isInFloatingElement ? Fragment : Portal;
 
     return isOpen ? (
-      <Portal>
+      <MaybePortal>
         <DropdownPane
           ref={mergeRefs(ref, setPaneEl)}
           arrowRef={setArrowEl}
@@ -63,7 +67,7 @@ const ControlledDropdown = forwardRef<
         >
           {children}
         </DropdownPane>
-      </Portal>
+      </MaybePortal>
     ) : null;
   },
 );


### PR DESCRIPTION
When dropdown-like component is used inside dialogs the focus trap prevented from clicking on interactive elements, because dropdowns are rendered into separate portals. This PR adds checking if the dropdown is used in dialog context and if dialog is detected dropdown is not rendered in portal.