### PR TITLE
chore(storybook): disable a11y addon

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -18,7 +18,7 @@ const config: StorybookConfig = {
         },
       },
     },
-    '@storybook/addon-a11y',
+    // '@storybook/addon-a11y',
     '@storybook/addon-designs',
     'storycap',
   ],


### PR DESCRIPTION
Turned out that the @storybook/addon-a11y somehow breaks Storybook when deployed to Github Pages. For now we disable this plugin.