### PR TITLE
fix(Stack): allow polymorphic behaviour for extended components

### DIFF
--- a/src/components/layout/Stack/Stack.stories.tsx
+++ b/src/components/layout/Stack/Stack.stories.tsx
@@ -2,26 +2,97 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import { Button } from '../../Button';
 import { Box } from '../mocks/Box';
-import Stack from './Stack';
+import Stack, { type StackProps } from './Stack';
 
 const meta = {
   title: 'layout/primitives/Stack',
   component: Stack,
   argTypes: {
+    gap: {
+      description: 'Whitespace between each child of the Stack',
+      options: [
+        'none',
+        'xxs',
+        'xs',
+        'sm',
+        'md',
+        'mdPlus',
+        'lg',
+        'lgPlus',
+        'xl',
+        'xlPlus',
+        'xxl',
+        'half-x',
+        '1x',
+        '2x',
+        '3x',
+        '4x',
+        '6x',
+        '8x',
+        '12x',
+        '16x',
+        '24x',
+        '32x',
+      ],
+      control: { type: 'select' },
+      table: {
+        type: {
+          summary:
+            "'none' | 'xxs' | 'xs' | 'sm' | 'md' | 'mdPlus' | 'lg' | 'lgPlus' | 'xl' | 'xlPlus' | 'xxl' | 'half-x' | '1x' | '2x' | '3x' | '4x' | '6x' | '8x' | '12x' | '16x' | '24x' | '32x'",
+        },
+        defaultValue: {
+          summary: "'none'",
+        },
+      },
+    },
     justify: {
+      description: 'Horizontal alignment of elements inside Stack',
       options: ['center', 'flex-end', 'flex-start', 'baseline', 'stretch'],
       control: { type: 'select' },
+      table: {
+        type: {
+          summary: "'center'| 'flex-end'| 'flex-start'| 'baseline'| 'stretch'",
+        },
+        defaultValue: {
+          summary: "'stretch'",
+        },
+      },
     },
     align: {
+      description: 'Vertical alignment of elements inside Stack',
       options: ['center', 'flex-end', 'flex-start', 'baseline', 'stretch'],
       control: { type: 'select' },
+      table: {
+        type: {
+          summary: "'center'| 'flex-end'| 'flex-start'| 'baseline'| 'stretch'",
+        },
+      },
+    },
+    splitAt: {
+      description:
+        'Index of element after which the Stack is splitted. Leave `undefined` for no splitting',
+      control: { type: 'number' },
+      table: {
+        type: {
+          summary: 'number',
+        },
+      },
+    },
+    isRecursive: {
+      description: 'Should apply gap recursively (on nested levels)',
+      control: { type: 'boolean' },
+      table: {
+        type: {
+          summary: 'boolean',
+        },
+      },
     },
   },
-} satisfies Meta<typeof Stack>;
+} satisfies Meta<StackProps>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<StackProps>;
 
 export const Playground: Story = {
   args: {

--- a/src/components/layout/Stack/Stack.tsx
+++ b/src/components/layout/Stack/Stack.tsx
@@ -1,9 +1,4 @@
-import {
-  type ComponentPropsWithRef,
-  type ElementType,
-  type ReactNode,
-  forwardRef,
-} from 'react';
+import { type ReactNode } from 'react';
 import styled from 'styled-components';
 import { prop } from 'ramda';
 import { isNotUndefined } from 'ramda-adjunct';
@@ -28,88 +23,63 @@ export interface StackProps {
    */
   align?: Property.JustifyContent;
   /**
-   * Index of element after which the Stack is splitted. Leave 'undefined' for no splitting.
+   * Index of element after which the Stack is splitted. Leave 'undefined' for no splitting
    */
   splitAt?: number;
   /**
    * Should apply gap recursively (on nested levels)
    */
   isRecursive?: boolean;
-  className?: string;
   children: ReactNode;
-  as?: ElementType;
 }
-type StackRootProps = {
-  $gap: StackProps['gap'];
-  $justify: StackProps['justify'];
-  $align: StackProps['align'];
-  $splitAt: StackProps['splitAt'];
-  $isRecursive: StackProps['isRecursive'];
-};
 
-const StackRoot = styled.div<StackRootProps>`
+const Stack = styled.div
+  .withConfig<StackProps>({
+    shouldForwardProp: (propName) =>
+      !['gap', 'justify', 'align', 'splitAt', 'isRecursive', 'theme'].includes(
+        propName,
+      ),
+  })
+  .attrs<StackProps, StackProps>(
+    ({ gap, justify, isRecursive, className, ...rest }) => ({
+      gap: gap ?? 'none',
+      justify: justify ?? 'stretch',
+      isRecursive: isRecursive ?? false,
+      className: cls(CLX_LAYOUT, className),
+      ...rest,
+    }),
+  )`
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
-  align-items: ${prop('$justify')};
-  justify-content: ${prop('$align')};
+  align-items: ${prop('justify')};
+  justify-content: ${prop('align')};
 
   /* FIXME: Until we remove 'margin' property from other components we need to
     increase specificity of those nesting , since it can be overridden by inner
     elements with the same specificity. This can lead to inconsistent output
     of visual test if styled-components puts CSS in different order into Head. */
-  ${({ $isRecursive }) => ($isRecursive ? '&&' : '&& >')} * {
+  ${({ isRecursive }) => (isRecursive ? '&&' : '&& >')} * {
     margin-top: 0;
     margin-bottom: 0;
   }
 
-  ${({ $isRecursive }) => ($isRecursive ? '&&' : '&& >')} * + * {
-    margin-top: ${({ $gap, theme }) => getSpace($gap, { theme })};
+  ${({ isRecursive }) => (isRecursive ? '&&' : '&& >')} * + * {
+    margin-top: ${({ gap, theme }) => getSpace(gap, { theme })};
   }
 
-  ${({ $splitAt }) =>
-    isNotUndefined($splitAt) &&
+  ${({ splitAt }) =>
+    isNotUndefined(splitAt) &&
     `
     :only-child {
       height: 100%;
     }
 
-    > :nth-child(${$splitAt}) {
+    > :nth-child(${splitAt}) {
       margin-bottom: auto;
     }
   `}
 `;
-
-const Stack = forwardRef<
-  HTMLDivElement,
-  StackProps & ComponentPropsWithRef<'div'>
->(
-  (
-    {
-      children,
-      gap = 'none',
-      justify = 'stretch',
-      align,
-      splitAt,
-      isRecursive = false,
-      ...props
-    }: StackProps & ComponentPropsWithRef<'div'>,
-    ref,
-  ) => (
-    <StackRoot
-      ref={ref}
-      $align={align}
-      $gap={gap}
-      $isRecursive={isRecursive}
-      $justify={justify}
-      $splitAt={splitAt}
-      {...props}
-      className={cls(CLX_LAYOUT, props?.className)}
-    >
-      {children}
-    </StackRoot>
-  ),
-);
 
 Stack.displayName = 'Stack';
 


### PR DESCRIPTION
Previous change introduced accidental breaking change extensively described in https://github.com/styled-components/styled-components/issues/2129. We removed wrapping into React component to revert to previous behaviour.