### PR TITLE
test(storybook): enable docker host in vite config NOTICKET

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -36,7 +36,10 @@ const config: StorybookConfig = {
     return mergeConfig(config, {
       define: {
         'process.env.STORYBOOK': true,
-    },
+      },
+      server: {
+        allowedHosts: ['host.docker.internal'],
+      },
     });
   }
 };


### PR DESCRIPTION
In vite@5.4.12 there was introduced breaking change in order to fix security vulnerability. The CORS protection is enabled by default and it's required to specify hosts that are allowed to connect to the dev server.