### PR TITLE
fix(DatatableV2): fix color hover. MAXX-760

### DIFF
--- a/src/tokens/color.css
+++ b/src/tokens/color.css
@@ -285,7 +285,7 @@
   --sscds-color-background-action-danger-ghost-active: var(--sscds-color-background-action-ghost-active);
   --sscds-color-background-action-danger-ghost-disabled: var(--sscds-color-background-action-ghost-disabled);
 
-  --sscds-color-background-selectable-hover: var(--sscds-color-neutral-alpha-3);
+  --sscds-color-background-selectable-hover: var(--sscds-color-neutral-3);
   --sscds-color-background-selectable-active: var(--sscds-color-primary-3);
 
   --sscds-color-background-pill-blue-default: var(--blue-3);


### PR DESCRIPTION
Fixes an issue in which the background color was transparent so the cells look overlap:
Before:
<img width="148" alt="image" src="https://github.com/user-attachments/assets/285193de-4d6f-4202-8466-d76582237bf9" />
After:
<img width="134" alt="image" src="https://github.com/user-attachments/assets/397857a8-fb2d-4f9c-ad92-cd88d7104c1c" />
