### PR TITLE
feat(DatatableV2): clear all rows in multi-page. MAXX-559

### DIFF
--- a/src/components/_internal/toolbars/SelectionToolbar.tsx
+++ b/src/components/_internal/toolbars/SelectionToolbar.tsx
@@ -152,6 +152,7 @@ type Instance<Data> = {
   getSelectedRowModel?: Table<Data>['getSelectedRowModel'];
   toggleAllRowsSelected?: Table<Data>['toggleAllRowsSelected'];
   setVirtualSelectAll?: (value: boolean) => void;
+  setRowSelection?: Table<Data>['setRowSelection'];
 };
 
 const getSelectedRowsCount = <Data,>(instance: Instance<Data>) => {
@@ -182,8 +183,8 @@ function SelectionToolbarReactTable<Data>({
       selectAllMode,
     },
     getPrePaginationRowModel,
-    toggleAllRowsSelected,
     setVirtualSelectAll,
+    setRowSelection,
   } = instance;
 
   const { isVirtualSelectAll } = getState();
@@ -200,7 +201,7 @@ function SelectionToolbarReactTable<Data>({
     <SelectionToolbarRoot>
       <SelectionToolbarItemCounter
         deselectAllRows={() => {
-          toggleAllRowsSelected(false);
+          setRowSelection({} as RowSelectionState); // Deselect all rows across all pages
           setVirtualSelectAll(false);
         }}
         isVirtualSelectAll={isVirtualSelectAll}


### PR DESCRIPTION
in MAX we want to be able do clear select across all pages in manual pagination mode. Currently, “Clear Selection” only unchecks the rows of the current page.

The behavior is only on the “Clear Selection” button*. The "toggle all" checkbox still only affects the current page.

JIRA ticket: https://zitenote.atlassian.net/jira/software/c/projects/MAXX/boards/2180?assignee=6384d3eb2acfad92d7b2d414&assignee=unassigned&selectedIssue=MAXX-559


https://github.com/user-attachments/assets/f5dad7fc-1a35-451a-b2ca-c27732d95bc7

