### PR TITLE
feat(DataTableV2): export MouseEvent to onRowClick. MAXX-2015

### DIFF
--- a/src/components/DatatableV2/Datatable.types.ts
+++ b/src/components/DatatableV2/Datatable.types.ts
@@ -13,7 +13,13 @@ import {
   TableOptions,
   TableState,
 } from '@tanstack/react-table';
-import { Dispatch, MutableRefObject, ReactNode, SetStateAction } from 'react';
+import {
+  Dispatch,
+  MouseEvent,
+  MutableRefObject,
+  ReactNode,
+  SetStateAction,
+} from 'react';
 
 import { RowAction } from '../_internal/buttons/RowActionsButton';
 
@@ -553,13 +559,15 @@ interface DatatableBaseOptions<D>
   /**
    * Callback that is called when user clicks anywhere in the row area. Clicking on the selection
    * checkbox, row expand button and the row actions stops event propagation and does not trigger
-   * the row click callback. We are passing argmuments into the callback:
+   * the row click callback. We are passing arguments into the callback:
    *  - `row` - current row, row data are accessible through `row.original`
    *  - `table` - current instance of the table
+   *  - `event` - underlying MouseEvent
    */
   onRowClick?: (props: {
     row: DatatableRow<D>;
     table: DatatableInstance<D>;
+    event: MouseEvent;
   }) => void;
 
   /**

--- a/src/components/DatatableV2/body/BodyRow.tsx
+++ b/src/components/DatatableV2/body/BodyRow.tsx
@@ -24,10 +24,10 @@ const BodyRow = <D,>({
         className="ds-table-body-row ds-table-row"
         data-active={hasOnRowClick ? id === activeRowId : undefined}
         data-selected={getIsSelected()}
-        onClick={() => {
+        onClick={(event) => {
           if (hasOnRowClick) {
             setActiveRowId(id);
-            onRowClick({ row, table });
+            onRowClick({ row, table, event });
           }
         }}
       >

--- a/src/components/DatatableV2/stories/RowOnClick.stories.tsx
+++ b/src/components/DatatableV2/stories/RowOnClick.stories.tsx
@@ -22,7 +22,8 @@ export default {
 export const RowOnClickEnabled: Story = Template.bind({});
 RowOnClickEnabled.args = {
   ...Template.args,
-  onRowClick: ({ row, table }) => action('row action')({ row, table }),
+  onRowClick: ({ row, table, event }) =>
+    action('row action')({ row, table, event }),
   enableRowActions: true,
   rowActions: [
     {


### PR DESCRIPTION
Adding the `MouseEvent` to the `onRowClick` callback in `DataTableV2`.

This will be used to determine if the `meta` or `ctrl` keys are pressed while the user clicks a row.

![image](https://github.com/user-attachments/assets/03ecb317-2371-440a-925f-0a6a54adcb80)
