### PR TITLE
fix(Breadcrumbs): console error by incorrect key placement. NO_TICKET

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -47,10 +47,13 @@ const insertSeparators = (items: ReactElement[]) => {
       return [
         ...prev,
         current,
-        <SeparatorListItem aria-hidden="true" style={{ display: 'flex' }}>
+        <SeparatorListItem
+          // eslint-disable-next-line react/no-array-index-key
+          key={`separator-${index}`}
+          aria-hidden="true"
+          style={{ display: 'flex' }}
+        >
           <Icon
-            // eslint-disable-next-line react/no-array-index-key
-            key={`separator-${index}`}
             color={ColorTypes.neutral600}
             name={SSCIconNames.angleRight}
             size="sm"


### PR DESCRIPTION
When a `SeparatorListItem` was added to wrap the separator, the `key` was not moved to the wrapper. Hence it was not being caught by the enclosing the `map` function, causing an `console.error` entry at every render.

This fix moves the `key` to the correct location.

![image](https://github.com/user-attachments/assets/bd92c76d-a05e-4457-88a1-cbbe77174f5e)
