### PR TITLE
fix(Drawer): dropdown menu click. PLAT-927

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -206,7 +206,8 @@ const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
                 const drawer = document.querySelector('[role="dialog"]');
                 return drawer as HTMLElement;
               },
-              clickOutsideDeactivates: hasBackdrop || clickOutsideToHide,
+              clickOutsideDeactivates: true,
+              returnFocusOnDeactivate: true,
               escapeDeactivates: true,
               allowOutsideClick: true,
             }}


### PR DESCRIPTION
## Description

The Drawer component's focus trap configuration interferes with dropdown menu interactions when dropdown menus are used within the drawer content. This causes the focus trap to deactivate unexpectedly, breaking accessibility and focus management.