### PR TITLE
feat(HexGrade): add isLegacy property.NOTICKET

### DIFF
--- a/src/components/HexGrade/HexGrade.tsx
+++ b/src/components/HexGrade/HexGrade.tsx
@@ -101,10 +101,11 @@ const HexGrade = ({
   isInverted = false,
   margin,
   className,
+  isLegacy,
   ...props
 }: HexGradeProps & ComponentPropsWithoutRef<'svg'>) => {
   const { experimental } = useContext(DSContext);
-  const hasLegacyColors = experimental.legacyHexgrade;
+  const hasLegacyColors = experimental.legacyHexgrade || isLegacy;
 
   return (
     <StyledSVG

--- a/src/components/HexGrade/HexGrade.types.ts
+++ b/src/components/HexGrade/HexGrade.types.ts
@@ -12,4 +12,5 @@ export interface HexGradeProps {
   isInverted?: boolean;
   margin?: SpacingSizeValue;
   className?: string;
+  isLegacy?: boolean;
 }


### PR DESCRIPTION
I need a prop to pass if the component uses legacy colors. There are cases where the component is used outside the DS provider (echarts), and it uses the experimental styles by default.

I tried wrapping it inside the DSProvider, but it glitches like crazy, and I don't think that's how the provider should be used anyway.