### PR TITLE
chore(deps): remove focus-trap library. PLAT-928

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "csstype": "^3.0.11",
     "dedent": "^1.5.1",
     "fast-deep-equal": "^3.1.3",
-    "focus-trap-react": "^11.0.4",
     "i18next": ">=17.3.1",
     "i18next-icu": "^1.4.2",
     "numeral": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3815,7 +3815,6 @@ __metadata:
     eslint-plugin-storybook: "npm:^0.9.0"
     eslint-plugin-testing-library: "npm:^7.1.0"
     fast-deep-equal: "npm:^3.1.3"
-    focus-trap-react: "npm:^11.0.4"
     happy-dom: "npm:^15.11.7"
     history: "npm:^5.3.0"
     http-server: "npm:^14.1.1"
@@ -9713,30 +9712,6 @@ __metadata:
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
   checksum: 10/7b8376061d5be6e0d3658bbab8bde587647f68797cf6bfeae9dea0e5137d9f27547ab92aaff3512dd9d1299086a6d61be98e9d48a56d17531b634f77faadbc49
-  languageName: node
-  linkType: hard
-
-"focus-trap-react@npm:^11.0.4":
-  version: 11.0.4
-  resolution: "focus-trap-react@npm:11.0.4"
-  dependencies:
-    focus-trap: "npm:^7.6.5"
-    tabbable: "npm:^6.2.0"
-  peerDependencies:
-    "@types/react": ^18.0.0 || ^19.0.0
-    "@types/react-dom": ^18.0.0 || ^19.0.0
-    react: ^18.0.0 || ^19.0.0
-    react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10/cdedee222cb990e768b5543bfa6905a97e4ebb8dfe775619ae92a6282875b880c5825cbd5e579e148553ba5b5e661c524bef22f6a4dc3e2071d6ef5aea0152af
-  languageName: node
-  linkType: hard
-
-"focus-trap@npm:^7.6.5":
-  version: 7.6.5
-  resolution: "focus-trap@npm:7.6.5"
-  dependencies:
-    tabbable: "npm:^6.2.0"
-  checksum: 10/99c002dd12fc14a5c95504d69d22150e44478379c7450c76166acf06675142a9a2acc3033891529eddfe00f7506987a2231551c67cacc060edcc4d3f82e07f2c
   languageName: node
   linkType: hard
 
@@ -18279,13 +18254,6 @@ __metadata:
     "@pkgr/core": "npm:^0.1.0"
     tslib: "npm:^2.6.2"
   checksum: 10/bff3903976baf8b699b5483228116d70223781a93b17c70e685c277ee960cdfd1a09cb5a741e6a9ec35e2428f14f4664baec41ccc99a598f267608b2a54f529b
-  languageName: node
-  linkType: hard
-
-"tabbable@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "tabbable@npm:6.2.0"
-  checksum: 10/980fa73476026e99dcacfc0d6e000d41d42c8e670faf4682496d30c625495e412c4369694f2a15cf1e5252d22de3c396f2b62edbe8d60b5dadc40d09e3f2dde3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changes
- Remove `focus-trap-react` from package.json dependencies

### Benefits
- Reduces bundle size by removing external dependency
- Eliminates transitive dependencies (`focus-trap`, `tabbable`)