### PR TITLE
feat(keyboard): radio and outline styles. PLAT-952

### DIFF
--- a/src/components/forms/Radio/Radio.tsx
+++ b/src/components/forms/Radio/Radio.tsx
@@ -86,6 +86,13 @@ const RadioInput = styled.input<TogglingInputProps>`
     border: 2px solid ${getFormStyle('activeBorderColor')};
   }
 
+  &:focus-visible + ${/* sc-selector */ RadioLabel} {
+    outline: var(--sscds-focus-indicator-width) solid
+      var(--sscds-focus-indicator-color);
+    outline-offset: var(--sscds-focus-outline-offset, -1px);
+    box-shadow: none;
+  }
+
   ${({ isInvalid }) =>
     isInvalid &&
     css`

--- a/src/theme/GlobalStyles/GlobalStyles.tsx
+++ b/src/theme/GlobalStyles/GlobalStyles.tsx
@@ -138,9 +138,10 @@ export default createGlobalStyle`
   }
   .sscds-tighter-focus {
     transition: none;
+    outline-offset: var(--sscds-tighter-focus-outline-offset);
     &:focus-visible {
-      outline-offset: -3px;
-      outline-width: 3px;
+      outline-offset: var(--sscds-tighter-focus-outline-offset);
+      outline-width: var(--sscds-tighter-focus-outline-width);
       box-shadow: none;
     }
   }
@@ -152,6 +153,8 @@ export default createGlobalStyle`
     --sscds-focus-outline-offset: -1px;
     --sscds-table-focus-outline-width: 3px;
     --sscds-table-focus-outline-offset: -3px;
+    --sscds-tighter-focus-outline-width: 3px;
+    --sscds-tighter-focus-outline-offset: -3px;
     --sscds-focus-indicator-color: var(--sscds-color-border-action-focused-high-contrast);
     --sscds-focus-indicator-width: 2px;
   }


### PR DESCRIPTION
# Changes
* Add outline styles for the Radio component to support visual indicator.
* Refactor to use variables instead of hardcoded numbers,.

<img width="976" height="262" alt="Screenshot 2025-09-24 at 2 45 11 PM" src="https://github.com/user-attachments/assets/5f5950e3-5255-44a9-a56c-d41126b6be64" />
